### PR TITLE
Full portfolio redesign: React SPA, dark mode, new typography & layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,390 @@
+# Portfolio Site — Claude Instructions
+
+## Tech stack
+Single-page React apps written in plain HTML files using Babel standalone (no build step). All styling is React inline styles. No external CSS framework.
+
+---
+
+## Dark mode architecture
+
+### How it works
+Dark mode is implemented via a React Context (`ThemeCtx`) and a `useC()` hook. Every component calls `const C = useC()` at the top to get the right color set — the hook returns `CD` (dark palette) or `C` (light palette) based on context.
+
+### Key files
+- `index.html` — main portfolio page, defines the canonical `C`, `CD`, `ThemeCtx`, `useC()` pattern
+- `resume.html` — resume page, same dark mode infrastructure
+- `projects/user-language-model.html` — project detail page, same infrastructure
+- `projects/instagram-latency.html` — project detail page, same infrastructure
+
+### Adding a new page — required checklist
+
+Every new page **must** include all of the following or dark mode will silently break:
+
+1. **Anti-flash script** (place immediately after `</style>` in `<head>`):
+   ```html
+   <script>(function(){try{if(localStorage.getItem('theme')==='dark')document.documentElement.classList.add('dark');}catch(e){}})()</script>
+   ```
+
+2. **Dark CSS rule** (inside the `<style>` tag):
+   ```css
+   body { ...; transition: background 0.25s ease, color 0.25s ease; }
+   html.dark body { background: #1C1A17; color: #F0EBE1; }
+   ```
+
+3. **Dark palette + context** (after `const C = {...}` in the script):
+   ```javascript
+   const CD = {
+     cream: '#1C1A17', creamDark: '#232019', creamCard: '#2B2722',
+     white: '#332E28', ink: '#F0EBE1', inkMid: '#B5A99A', inkLight: '#7A7065',
+     border: 'rgba(240,235,225,0.09)', borderMid: 'rgba(240,235,225,0.14)',
+   };
+   const ThemeCtx = React.createContext(false);
+   function useC() { const dark = React.useContext(ThemeCtx); return dark ? CD : C; }
+   ```
+
+4. **Every component** that references colors must call `const C = useC()` at the top of the function body. This shadows the module-level `C` with the themed version.
+
+5. **Root component** (the one that renders the page) must:
+   - Read dark state from localStorage
+   - Sync `classList.toggle('dark', dark)` in a `useEffect`
+   - Wrap its return in `<ThemeCtx.Provider value={dark}>...</ThemeCtx.Provider>`
+   - Use `const T = dark ? CD : C` for its own JSX (cannot use `useC()` — it is the provider)
+
+6. **Nav toggle** must show sun icon in light mode and moon icon in dark mode (see `index.html` for the conditional SVG pattern).
+
+### Special cases
+
+**Dark-background sections** (stats bars, Footer): These use `C.ink` (`#1C1810`) as background in light mode. In dark mode `C.ink` becomes the light text color (`#F0EBE1`), which is wrong for a background. Fix: hardcode the background conditionally:
+```javascript
+background: dark ? '#0D0B09' : '#1C1810'
+```
+
+**Root component color access**: The root component creates `ThemeCtx.Provider` and therefore cannot consume `useC()` (context not yet available to itself). Use `const T = dark ? CD : C` as a local alias instead. Note: `const C = dark ? CD : C` causes a temporal dead zone error — always use a different variable name like `T`.
+
+**Hardcoded `'#fff'` backgrounds**: These need updating for dark mode. Replace with `C.white` (which maps to `#332E28` in dark mode). Examples: floating image cards, PDF viewer container.
+
+**Sections with non-palette (hardcoded) backgrounds**: Any section that uses a hardcoded gradient or color instead of a palette token (e.g., Testimonials) must be made dark-mode aware explicitly. Components that only call `useC()` get the palette but not the raw `dark` boolean — they cannot conditionally swap a hardcoded gradient. The fix: consume the context directly and branch the background:
+```javascript
+function MySection() {
+  const C = useC();
+  const dark = React.useContext(ThemeCtx);
+  // ...
+  background: dark ? 'linear-gradient(...)' : 'linear-gradient(...)'
+```
+The Testimonials section uses this pattern:
+- Light: `linear-gradient(160deg, #c93a06 0%, #decbc3 100%)`
+- Dark: `linear-gradient(160deg, #3a1508 0%, #1a1412 100%)`
+
+The card backgrounds inside (`C.cream`, `C.white`) then work correctly in both modes since they invert automatically with the palette.
+
+### Persistence across pages
+Preference is saved to `localStorage` under the key `'theme'` with values `'dark'` or `'light'`. The anti-flash script reads this before React loads to prevent a white flash. All pages read and write to the same key, so toggling on any page persists to all others.
+
+### Default mode
+Light mode is the default. New visitors with no localStorage entry get `null === 'dark'` → `false` → light mode.
+
+---
+
+## Color palettes
+
+### Light (`C`)
+```javascript
+cream: '#F4EFE6',  creamDark: '#EDE5D8',  creamCard: '#EAE3D5',
+white: '#FFFFFF',  ink: '#1C1810',         inkMid: '#4A3F32',
+inkLight: '#8A7E70',  border: 'rgba(28,24,16,0.11)',  borderMid: 'rgba(28,24,16,0.18)'
+```
+
+### Dark (`CD`)
+```javascript
+cream: '#1C1A17',  creamDark: '#232019',  creamCard: '#2B2722',
+white: '#332E28',  ink: '#F0EBE1',         inkMid: '#B5A99A',
+inkLight: '#7A7065',  border: 'rgba(240,235,225,0.09)',  borderMid: 'rgba(240,235,225,0.14)'
+```
+
+Accent color `ACC = '#D95F2B'` is the same in both modes.
+
+---
+
+## Shared utility functions — include on every page
+
+Every page must declare these exact implementations (copy verbatim):
+
+```javascript
+function useWindowWidth() {
+  const [width, setWidth] = useState(typeof window !== 'undefined' ? window.innerWidth : 1200);
+  useEffect(() => {
+    const fn = () => setWidth(window.innerWidth);
+    window.addEventListener('resize', fn);
+    return () => window.removeEventListener('resize', fn);
+  }, []);
+  return width;
+}
+
+function hPad(w) {
+  if (w < 768) return '20px';
+  if (w < 1024) return '32px';
+  return 'max(56px, calc((100vw - 1280px) / 2))';
+}
+```
+
+Include `useInView` on any page with scroll animations:
+```javascript
+function useInView(ref, threshold = 0.1) {
+  const [v, setV] = useState(false);
+  useEffect(() => {
+    if (!ref.current) return;
+    const obs = new IntersectionObserver(([e]) => { if (e.isIntersecting) { setV(true); obs.disconnect(); } }, { threshold });
+    obs.observe(ref.current);
+    return () => obs.disconnect();
+  }, []);
+  return v;
+}
+```
+
+Include `useCounter` on any page with animated stat numbers:
+```javascript
+function useCounter(target, visible, duration = 1200) {
+  const [val, setVal] = useState(0);
+  useEffect(() => {
+    if (!visible) return;
+    let start = null;
+    const step = ts => {
+      if (!start) start = ts;
+      const p = Math.min((ts - start) / duration, 1);
+      setVal(Math.round((1 - Math.pow(1 - p, 3)) * target));
+      if (p < 1) requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+  }, [visible, target]);
+  return val;
+}
+```
+
+---
+
+## Responsive breakpoints
+
+Consistent across all pages — never deviate:
+
+| Breakpoint | Variable | Value |
+|---|---|---|
+| Mobile | `isMobile` | `w < 768` |
+| Tablet | `isTablet` | `w < 1024` |
+| Footer/Testimonials mobile | `isMobile` | `w < 640` |
+| Testimonials tablet | `isTablet` | `w < 960` |
+
+The `hPad(w)` function uses these exact same thresholds. Padding tiers: `20px` (mobile) → `32px` (tablet) → `max(56px, calc((100vw - 1280px) / 2))` (desktop, max-width 1280px centered).
+
+---
+
+## Navbar — canonical component
+
+The `Nav` component is identical across all pages except for `navLinks` (relative paths differ by depth). Always includes:
+- Fixed position, `zIndex: 200`
+- Logo: orange "R" badge (32×32px, `borderRadius: 6`) + "Rohan Vartak" text
+- Scroll-triggered frosted-glass effect at `scrollY > 50`: `${C.cream}f0` background + `blur(16px)` backdrop
+- Dark mode toggle (moon SVG in dark mode, sun SVG in light mode)
+- Desktop: nav links + "Get in Touch" CTA pill (ACC background, `borderRadius: 100`)
+- Mobile: hamburger menu toggle instead of nav links + CTA; menu opens below nav
+
+**Nav links (always these 4, in this order):** Projects, Skills, Testimonials, Resume
+
+**Path rules by page depth:**
+
+| Page | Logo href | Nav link base | "Get in Touch" href |
+|---|---|---|---|
+| `index.html` | `#hero` | `#projects`, `#skills`, etc. | `#contact` |
+| `resume.html` | `index.html` | `index.html#projects`, etc. | `index.html#contact` |
+| `projects/*.html` | `../index.html` | `../index.html#projects`, etc. | `../index.html#contact` |
+
+Never change the nav link labels or order without updating every page.
+
+---
+
+## Footer — canonical component
+
+Identical across all pages except internal link paths (same depth rules as Nav). Always:
+- Uses `dark ? '#0D0B09' : '#1C1810'` background — **never** use `C.ink` for this (it inverts in dark mode)
+- 4-column grid on desktop (`2fr 1fr 1fr 1fr`), `1fr 1fr` on mobile with brand spanning full width
+- Columns: Brand tagline | Work (Projects, Skills, Resume) | Social (LinkedIn, GitHub) | Contact (Get in Touch)
+- Footer text colors use hardcoded `rgba(255,255,255,*)` — not palette tokens — because background is always dark
+- Copyright: `Designed by Rohan Vartak © 2025` on left; email link on right
+
+Footer consumes `ThemeCtx` directly via `React.useContext(ThemeCtx)` (not `useC()`) because it needs the raw `dark` boolean for the hardcoded background.
+
+**Exact font sizes — must match across every page:**
+
+| Element | `fontSize` |
+|---|---|
+| Logo "R" badge | `13` |
+| "Rohan Vartak" text | `14` |
+| Tagline paragraph | `13` |
+| Column label (uppercase) | `10` |
+| Column links | `13` |
+| Copyright / email | `12` |
+
+When copying the Footer to a new page, copy verbatim — do not resize any of these.
+
+---
+
+## Scroll-to-anchor on page load
+
+`index.html`'s root `App` component includes this effect to handle deep-link navigation (e.g., from project pages back to `index.html#projects`):
+
+```javascript
+useEffect(() => {
+  const hash = window.location.hash;
+  if (!hash) return;
+  requestAnimationFrame(() => {
+    const el = document.querySelector(hash);
+    if (el) el.scrollIntoView({ behavior: 'instant' });
+  });
+}, []);
+```
+
+Include this on any page that may be navigated to with a hash anchor.
+
+---
+
+## Page structure patterns
+
+### Root component naming
+- `index.html` → `function App()`
+- `resume.html` → `function ResumePage()`
+- `projects/*.html` → `function ProjectPage()`
+
+All follow the same ThemeCtx.Provider pattern. The root component uses `const T = dark ? CD : C` (not `useC()`) for its own JSX.
+
+### Sub-page (project detail) anatomy
+```
+Nav (fixed)
+  └─ Hero section: padding '120px 0 0', dot-grid background, ← Back to Projects link, title, tags
+  └─ Dark stats strip: background dark ? '#0D0B09' : '#1C1810'
+  └─ Content: maxWidth: 860, margin: '0 auto' — Section components with useInView animation
+  └─ Footer
+```
+
+### Back-navigation links
+- Project pages: `← Back to Projects` → `../index.html#projects`
+- Resume page: `← Back to Portfolio` → `index.html`
+
+---
+
+## Scroll-reveal animation pattern
+
+All sections and cards use this standard animation on scroll entry (fire once, never reverse):
+
+```javascript
+const ref = useRef(null);
+const visible = useInView(ref);
+// ...
+<div ref={ref} style={{
+  opacity: visible ? 1 : 0,
+  transform: visible ? 'none' : 'translateY(20px)',
+  transition: 'all 0.55s ease',
+}}>
+```
+
+For staggered children (e.g., skill rows), bake the delay into the `transition` string:
+```javascript
+transition: `all 0.55s ease ${idx * 0.1}s`
+```
+
+### Stagger + hover conflict (important)
+
+When a card has **both** a scroll-reveal stagger **and** hover effects, never use `transition: 'all ...'` and never use a separate `transitionDelay` property. The reason: React inline `transitionDelay` applies to the **target** state, so by the time `visible` flips to `true`, the delay is already `'0s'` in the target — the stagger never fires. And `opacity` must be named explicitly or it won't animate at all.
+
+Correct pattern for cards with both concerns:
+```javascript
+transition: visible
+  ? 'background 0.2s, box-shadow 0.2s, transform 0.2s, opacity 0.55s'
+  : `background 0.2s, box-shadow 0.2s, transform 0.55s ${delay}s, opacity 0.55s ${delay}s`,
+```
+This staggered before reveal; after reveal, hover snaps at 0.2s as expected. Do **not** add a separate `transitionDelay` property alongside this.
+
+---
+
+## Reusable UI primitives
+
+### Main page (`index.html`)
+```javascript
+function Eyebrow({ children, style })  // uppercase label, fontSize 11, letterSpacing 0.18em, C.inkLight
+function SectionHeading({ plain, italic, light })  // Playfair 900, clamp(28px, 4vw, 54px), ACC italic span
+```
+
+### Project detail pages (`projects/*.html`)
+```javascript
+function SectionLabel({ children })  // same as Eyebrow
+function SectionTitle({ children })  // Playfair 800, clamp(26px, 3vw, 38px)
+function SubTitle({ children })      // DM Sans 700, fontSize 17
+function Body({ children })          // DM Sans 15, lineHeight 1.75, C.inkMid
+function BulletList({ items })       // ACC dot bullets, fontSize 15, C.inkMid
+function Section({ children })       // useInView wrapper with border-top + fade-up animation
+```
+
+Do not mix primitives across page types — define the appropriate set per page.
+
+---
+
+## Visual design rules
+
+### Dot-grid background
+Used in hero sections and project page headers:
+```javascript
+backgroundImage: `radial-gradient(circle, ${C.border} 1px, transparent 1px)`,
+backgroundSize: '28px 28px',
+opacity: 0.5,  // (hero section uses 0.6)
+pointerEvents: 'none',
+```
+
+### Tag / pill style
+Consistent across project cards and project page headers:
+```javascript
+background: `${ACC}15`, color: ACC, border: `1px solid ${ACC}30`,
+borderRadius: 100, padding: '5px 14px', fontSize: 12, fontWeight: 500
+```
+
+### Card hover effect
+Standard pattern for interactive cards:
+```javascript
+background: hovered ? C.white : C.creamCard,
+border: `1px solid ${C.border}`,
+borderRadius: 14,
+boxShadow: hovered ? '0 12px 40px rgba(28,24,16,0.12)' : '0 2px 8px rgba(28,24,16,0.04)',
+transform: hovered ? 'translateY(-3px)' : 'none',
+transition: 'background 0.2s, box-shadow 0.2s, transform 0.2s',
+```
+
+### Dark stats strip
+Inline stats bars (hero, project pages) always use hardcoded dark backgrounds:
+```javascript
+background: dark ? '#0D0B09' : '#1C1810'
+```
+Text colors inside are hardcoded: `rgba(255,255,255,0.85)` for values, `rgba(255,255,255,0.4)` for sublabels, `rgba(255,255,255,0.08)` for dividers.
+
+### CTA buttons
+Primary (filled): `background: ACC, color: '#fff', borderRadius: 100, padding: '12px 26px', fontSize: 14, fontWeight: 600`
+Secondary (outline): `background: transparent, border: '1.5px solid ${C.borderMid}', borderRadius: 100, padding: '11px 24px'`
+Hover on primary: `opacity: 0.88`. Hover on secondary: `borderColor: ACC, color: ACC`.
+
+### Typography scale
+- Page eyebrow/label: DM Sans 11px, weight 500, `letterSpacing: '0.18em'`, uppercase, `C.inkLight`
+- Section heading: Playfair Display 900, `clamp(28px, 4vw, 54px)`, `letterSpacing: '-0.025em'`
+- Hero h1: Playfair Display 900, `clamp(49px, 5vw, 67px)` desktop / `clamp(45px, 11vw, 59px)` mobile
+- Body: DM Sans 15px, `lineHeight: 1.7`, `C.inkMid`
+- Nav links: DM Sans 13px, weight 500, `C.inkMid`, hover → `ACC`
+
+---
+
+## State persistence rules
+
+- **Dark mode**: `localStorage` key `'theme'`, values `'dark'` / `'light'`. Read on init, write on toggle. Persists across all pages automatically.
+- **Form state** (Contact): Local React state only — not persisted. `sent` state gates the success message; `sending` state disables the submit button.
+- **Nav scroll/menu state**: Local to `Nav` component, resets on navigation (correct behavior).
+- No other state is persisted to localStorage.
+
+---
+
+## Orphaned files — do not reference
+
+`style.css` and `projects/projects.css` are leftover from the old portfolio design (purple color scheme, Geist font, old nav class names). No page links to either file. They are safe to delete but currently kept in the repo. Do not import, link, or build on top of these files.

--- a/index.html
+++ b/index.html
@@ -1,328 +1,800 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
-        integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg=="
-        crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <title>Rohan Vartak | Data Scientist &amp; ML Engineer at Meta</title>
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🚀</text></svg>">
-    <meta name="description" content="Full-stack data scientist with 5+ years of experience building ML systems at Meta. Specializing in user behavior prediction, product analytics, and AI-driven product decisions.">
-
-    <!-- Open Graph / LinkedIn / Slack previews -->
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://rohanvartak96.github.io/">
-    <meta property="og:title" content="Rohan Vartak | Data Scientist &amp; ML Engineer">
-    <meta property="og:description" content="Building ML systems that move product metrics at scale. Currently at Meta.">
-    <meta property="og:image" content="https://rohanvartak96.github.io/images/Rohan2.webp">
-
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Rohan Vartak | Data Scientist &amp; ML Engineer">
-    <meta name="twitter:description" content="Building ML systems that move product metrics at scale. Currently at Meta.">
-    <meta name="twitter:image" content="https://rohanvartak96.github.io/images/Rohan2.webp">
-
-    <!-- AOS Animate on Scroll -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.css" />
-    <link rel="stylesheet" href="style.css">
-    <script src="script.js" defer></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Rohan Vartak | Data Scientist & ML Engineer</title>
+<meta name="description" content="Full-stack data scientist with 5+ years of experience building ML systems at Meta. Specializing in user behavior prediction, product analytics, and AI-driven product decisions.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://rohanvartak96.github.io/">
+<meta property="og:title" content="Rohan Vartak | Data Scientist & ML Engineer">
+<meta property="og:description" content="Building ML systems that move product metrics at scale. Currently at Meta.">
+<meta property="og:image" content="https://rohanvartak96.github.io/images/Rohan2.webp">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Rohan Vartak | Data Scientist & ML Engineer">
+<meta name="twitter:description" content="Building ML systems that move product metrics at scale. Currently at Meta.">
+<meta name="twitter:image" content="https://rohanvartak96.github.io/images/Rohan2.webp">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='18' fill='%23D95F2B'/><text x='50' y='76' font-family='Playfair Display,serif' font-weight='900' font-size='68' fill='%23fff' text-anchor='middle'>R</text></svg>">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;0,800;0,900;1,700;1,800&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600;9..40,700;9..40,800&display=swap" rel="stylesheet">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<style>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
+body { background: #F4EFE6; color: #1C1810; font-family: 'DM Sans', sans-serif; -webkit-font-smoothing: antialiased; transition: background 0.25s ease, color 0.25s ease; }
+html.dark body { background: #1C1A17; color: #F0EBE1; }
+::selection { background: #D95F2B; color: #fff; }
+</style>
+<script>(function(){try{if(localStorage.getItem('theme')==='dark')document.documentElement.classList.add('dark');}catch(e){}})()</script>
 </head>
-
 <body>
-    <header class="navbar-outer">
-        <nav>
-            <div class="left">
-                <a href="#hero">🚀 Rohan Vartak</a>
-            </div>
-            <div class="right">
-                <div class="nav-links" id="nav-links">
-                    <a href="#projects" class="nav-link" data-section="projects">Projects</a>
-                    <a href="#testimonial-highlights" class="nav-link" data-section="testimonial-highlights">Testimonials</a>
-                    <a href="resume.html" class="nav-link" data-section="resume">Resume</a>
-                    <a href="#contact" class="nav-link nav-link--cta" data-section="contact">
-                        <i class="fa-solid fa-envelope"></i>
-                        <span>Contact</span>
-                    </a>
-                </div>
-                <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                </button>
-            </div>
-        </nav>
-    </header>
-    <main>
-        <!-- SECTION 1: Hero -->
-        <section id="hero" class="hero-section">
-            <div class="hero-heading">
-                <h2>Hi, I'm Rohan.</h2>
-                <h2 class="job-title">I build <span class="flip-words"><span class="flip-word">ML models</span><span class="flip-word">Data pipelines</span><span class="flip-word">Strategic analysis</span><span class="flip-word">AI agents</span></span></h2>
-            </div>
-            <div class="headshot">
-                <div class="headshot-text">
-                    <p>I specialize in:</p>
-                    <p>Transforming data into actionable product insights.</p>
-                    <p>Building AI systems to solve real world problems.</p>
-                    <div class="hero-cta">
-                        <a href="#projects" class="hero-btn hero-btn--primary">View Projects</a>
-                        <a href="resume.html" class="hero-btn hero-btn--secondary"><i class="fa-solid fa-file-lines"></i> Resume</a>
-                        <a href="https://www.linkedin.com/in/rohanvartak1996/" target="_blank" class="hero-btn hero-btn--linkedin"><i class="fa-brands fa-linkedin"></i> LinkedIn</a>
-                    </div>
-                </div>
-                <div class="headshot-image">
-                    <img src="images/Rohan2.webp" alt="Rohan Headshot">
-                </div>
-            </div>
-            <div class="text">
-                <p>Full-stack data scientist with 5+ years of experience. Currently working at Meta at the intersection
-                    of Machine Learning and Product Analytics. I build and improve ML models serving billions of users,
-                    translating user behavior signals into measurable business outcomes across Meta's product suite.</p>
-                <p class="role-target"><i class="fa-solid fa-circle-dot pulse-green"></i> Open to Senior ML / Data Science roles at product-led companies</p>
-            </div>
-        </section>
-        <!-- Metrics Bar -->
-        <div class="metrics-bar">
-            <div class="metric">
-                <span class="metric-value">5+</span>
-                <span class="metric-label">Years Experience</span>
-            </div>
-            <div class="metric-divider"></div>
-            <div class="metric">
-                <span class="metric-value">$116M+</span>
-                <span class="metric-label">ARR Impact</span>
-            </div>
-            <div class="metric-divider"></div>
-            <div class="metric">
-                <span class="metric-value">1B+</span>
-                <span class="metric-label">Users Reached</span>
-            </div>
-            <div class="metric-divider"></div>
-            <div class="metric">
-                <span class="metric-value">Meta · Instagram · Threads</span>
-                <span class="metric-label">Products Shipped</span>
-            </div>
+<div id="root"></div>
+<script type="text/babel">
+const { useState, useEffect, useRef } = React;
+
+const ACC = '#D95F2B';
+const C = {
+  cream:     '#F4EFE6',
+  creamDark: '#EDE5D8',
+  creamCard: '#EAE3D5',
+  white:     '#FFFFFF',
+  ink:       '#1C1810',
+  inkMid:    '#4A3F32',
+  inkLight:  '#8A7E70',
+  border:    'rgba(28,24,16,0.11)',
+  borderMid: 'rgba(28,24,16,0.18)',
+};
+
+const CD = {
+  cream:     '#1C1A17',
+  creamDark: '#232019',
+  creamCard: '#2B2722',
+  white:     '#332E28',
+  ink:       '#F0EBE1',
+  inkMid:    '#B5A99A',
+  inkLight:  '#7A7065',
+  border:    'rgba(240,235,225,0.09)',
+  borderMid: 'rgba(240,235,225,0.14)',
+};
+
+const ThemeCtx = React.createContext(false);
+function useC() { const dark = React.useContext(ThemeCtx); return dark ? CD : C; }
+
+function useInView(ref, threshold = 0.1) {
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    if (!ref.current) return;
+    const obs = new IntersectionObserver(([e]) => { if (e.isIntersecting) { setVisible(true); obs.disconnect(); } }, { threshold });
+    obs.observe(ref.current);
+    return () => obs.disconnect();
+  }, []);
+  return visible;
+}
+
+function useCounter(target, visible, duration = 1200) {
+  const [val, setVal] = useState(0);
+  useEffect(() => {
+    if (!visible) return;
+    let start = null;
+    const step = (ts) => {
+      if (!start) start = ts;
+      const p = Math.min((ts - start) / duration, 1);
+      const ease = 1 - Math.pow(1 - p, 3);
+      setVal(Math.round(ease * target));
+      if (p < 1) requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+  }, [visible, target]);
+  return val;
+}
+
+function useWindowWidth() {
+  const [width, setWidth] = useState(typeof window !== 'undefined' ? window.innerWidth : 1200);
+  useEffect(() => {
+    const fn = () => setWidth(window.innerWidth);
+    window.addEventListener('resize', fn);
+    return () => window.removeEventListener('resize', fn);
+  }, []);
+  return width;
+}
+
+function hPad(w) {
+  if (w < 768) return '20px';
+  if (w < 1024) return '32px';
+  return 'max(56px, calc((100vw - 1280px) / 2))';
+}
+
+function Nav({ dark, setDark }) {
+  const C = useC();
+  const [scrolled, setScrolled] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const w = useWindowWidth();
+  const isMobile = w < 768;
+
+  useEffect(() => {
+    const fn = () => setScrolled(window.scrollY > 50);
+    window.addEventListener('scroll', fn);
+    return () => window.removeEventListener('scroll', fn);
+  }, []);
+
+  const navLinks = [['Projects','#projects'],['Skills','#skills'],['Testimonials','#testimonials'],['Resume','resume.html']];
+
+  return (
+    <nav style={{
+      position: 'fixed', top: 0, left: 0, right: 0, zIndex: 200,
+      background: (scrolled || menuOpen) ? `${C.cream}f0` : 'transparent',
+      backdropFilter: (scrolled || menuOpen) ? 'blur(16px)' : 'none',
+      borderBottom: (scrolled || menuOpen) ? `1px solid ${C.border}` : '1px solid transparent',
+      transition: 'all 0.3s ease',
+    }}>
+      <div style={{
+        padding: isMobile ? '14px 20px' : `16px ${hPad(w)}`,
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+      }}>
+        <a href="#hero" style={{ display: 'flex', alignItems: 'center', gap: 10, textDecoration: 'none' }}>
+          <div style={{ width: 32, height: 32, borderRadius: 6, background: ACC, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'Playfair Display', fontWeight: 900, fontSize: 16, color: '#fff' }}>R</div>
+          <span style={{ fontFamily: 'DM Sans', fontWeight: 600, fontSize: 15, color: C.ink, letterSpacing: '-0.01em' }}>Rohan Vartak</span>
+        </a>
+
+        {!isMobile && (
+          <div style={{ display: 'flex', gap: 28, alignItems: 'center' }}>
+            {navLinks.map(([l,h]) => (
+              <a key={l} href={h} style={{ fontFamily: 'DM Sans', fontSize: 13, fontWeight: 500, color: C.inkMid, textDecoration: 'none', letterSpacing: '0.01em', transition: 'color 0.2s' }}
+                onMouseEnter={e => e.target.style.color = ACC}
+                onMouseLeave={e => e.target.style.color = C.inkMid}
+              >{l}</a>
+            ))}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+          <button onClick={() => setDark(d => !d)} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 8, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: C.inkMid, transition: 'color 0.2s, background 0.2s', outline: 'none' }}
+            onMouseEnter={e => { e.currentTarget.style.color = C.ink; e.currentTarget.style.background = C.creamCard; }}
+            onMouseLeave={e => { e.currentTarget.style.color = C.inkMid; e.currentTarget.style.background = 'none'; }}
+            title={dark ? 'Switch to light mode' : 'Switch to dark mode'}
+          >
+            {dark ? (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+              </svg>
+            ) : (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="4.5"/>
+                <line x1="12" y1="2" x2="12" y2="4.5"/>
+                <line x1="12" y1="19.5" x2="12" y2="22"/>
+                <line x1="4.22" y1="4.22" x2="5.93" y2="5.93"/>
+                <line x1="18.07" y1="18.07" x2="19.78" y2="19.78"/>
+                <line x1="2" y1="12" x2="4.5" y2="12"/>
+                <line x1="19.5" y1="12" x2="22" y2="12"/>
+                <line x1="4.22" y1="19.78" x2="5.93" y2="18.07"/>
+                <line x1="18.07" y1="5.93" x2="19.78" y2="4.22"/>
+              </svg>
+            )}
+          </button>
+          {isMobile ? (
+            <button onClick={() => setMenuOpen(o => !o)} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 8, display: 'flex', alignItems: 'center', color: C.inkMid }}>
+              {menuOpen ? (
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+              ) : (
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+              )}
+            </button>
+          ) : (
+            <a href="#contact" style={{
+              background: ACC, color: '#fff', border: 'none', borderRadius: 100,
+              padding: '9px 20px', fontSize: 13, fontWeight: 600, cursor: 'pointer',
+              fontFamily: 'DM Sans', textDecoration: 'none', transition: 'opacity 0.2s',
+            }}
+              onMouseEnter={e => e.currentTarget.style.opacity = '0.85'}
+              onMouseLeave={e => e.currentTarget.style.opacity = '1'}
+            >Get in Touch</a>
+          )}
+        </div>
+      </div>
+
+      {isMobile && menuOpen && (
+        <div style={{ padding: '8px 20px 20px', borderTop: `1px solid ${C.border}`, display: 'flex', flexDirection: 'column', gap: 4 }}>
+          {navLinks.map(([l,h]) => (
+            <a key={l} href={h} onClick={() => setMenuOpen(false)} style={{ fontFamily: 'DM Sans', fontSize: 15, fontWeight: 500, color: C.inkMid, textDecoration: 'none', padding: '10px 0', borderBottom: `1px solid ${C.border}`, transition: 'color 0.2s' }}
+              onMouseEnter={e => e.target.style.color = ACC}
+              onMouseLeave={e => e.target.style.color = C.inkMid}
+            >{l}</a>
+          ))}
+          <a href="#contact" onClick={() => setMenuOpen(false)} style={{ background: ACC, color: '#fff', borderRadius: 100, padding: '12px 24px', fontSize: 14, fontWeight: 600, textDecoration: 'none', textAlign: 'center', marginTop: 8 }}>Get in Touch</a>
+        </div>
+      )}
+    </nav>
+  );
+}
+
+const ROLES = ['ML models', 'Data pipelines', 'AI agents', 'Strategic analysis'];
+
+function Hero() {
+  const C = useC();
+  const [roleIdx, setRoleIdx] = useState(0);
+  const [fading, setFading] = useState(false);
+  const w = useWindowWidth();
+  const isMobile = w < 768;
+  const isTablet = w < 1024;
+
+  useEffect(() => {
+    const iv = setInterval(() => {
+      setFading(true);
+      setTimeout(() => { setRoleIdx(i => (i+1) % ROLES.length); setFading(false); }, 280);
+    }, 2400);
+    return () => clearInterval(iv);
+  }, []);
+
+  return (
+    <section id="hero" style={{
+      minHeight: '100vh',
+      background: C.cream,
+      display: 'flex',
+      flexDirection: isMobile ? 'column' : 'row',
+      alignItems: isMobile ? 'flex-start' : 'center',
+      justifyContent: isMobile ? 'flex-start' : 'space-between',
+      padding: isMobile ? `80px 20px 48px` : `0 ${hPad(w)}`,
+      position: 'relative',
+      overflow: 'hidden',
+      gap: isMobile ? 16 : 0,
+    }}>
+      <div style={{ position: 'absolute', inset: 0, backgroundImage: `radial-gradient(circle, ${C.border} 1px, transparent 1px)`, backgroundSize: '28px 28px', pointerEvents: 'none', opacity: 0.6 }}></div>
+
+      <div style={{ flex: '1 1 0', maxWidth: isMobile ? '100%' : 620, paddingTop: isMobile ? 0 : 80, paddingBottom: isMobile ? 0 : 80, position: 'relative', width: '100%' }}>
+        <div style={{ height: isMobile ? 0 : 37, marginBottom: isMobile ? 16 : 28 }}></div>
+
+        <p style={{ fontFamily: 'DM Sans', fontSize: 11, fontWeight: 500, letterSpacing: '0.18em', textTransform: 'uppercase', color: C.inkLight, marginBottom: 18 }}>Data Scientist &amp; ML Engineer at Meta</p>
+
+        <h1 style={{ fontFamily: 'Playfair Display, serif', fontWeight: 900, fontSize: isMobile ? 'clamp(45px, 11vw, 59px)' : 'clamp(49px, 5vw, 67px)', lineHeight: 1.0, letterSpacing: '-0.025em', color: C.ink, marginBottom: 4 }}>
+          Hi, I'm Rohan.<br />I build
+        </h1>
+        <div style={{
+          fontFamily: 'Playfair Display, serif',
+          fontWeight: 800,
+          fontStyle: 'italic',
+          fontSize: isMobile ? 'clamp(45px, 11vw, 59px)' : 'clamp(49px, 5vw, 67px)',
+          lineHeight: 1.05,
+          letterSpacing: '-0.025em',
+          color: ACC,
+          opacity: fading ? 0 : 1,
+          transform: fading ? 'translateY(8px)' : 'translateY(0)',
+          transition: 'opacity 0.28s ease, transform 0.28s ease',
+          minHeight: '1.05em',
+          marginBottom: 28,
+        }}>{ROLES[roleIdx]}</div>
+
+        <div style={{ fontFamily: 'DM Sans', fontSize: 16, lineHeight: 1.7, color: C.inkMid, maxWidth: 480, marginBottom: 36 }}>
+          <p style={{ marginBottom: 10 }}>Full-stack data scientist with 5+ years at Meta. I specialize in:</p>
+          <p style={{ paddingLeft: 16, borderLeft: `2px solid ${ACC}`, marginBottom: 8 }}>Transforming data into actionable product insights.</p>
+          <p style={{ paddingLeft: 16, borderLeft: `2px solid ${ACC}` }}>Building AI systems to solve real world problems.</p>
         </div>
 
-        <!-- SECTION 3: Projects -->
-        <section id="projects" class="projects-section reveal">
-            <h2 data-aos="fade-up">Projects</h2>
+        <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginBottom: isMobile ? 0 : 52 }}>
+          {[
+            { label: 'View Projects', href: '#projects', primary: true },
+            { label: 'Resume', href: 'resume.html', primary: false },
+            { label: 'LinkedIn', href: 'https://www.linkedin.com/in/rohanvartak1996/', primary: false },
+          ].map(b => (
+            <a key={b.label} href={b.href} target={b.href.startsWith('http') ? '_blank' : undefined} style={{
+              background: b.primary ? ACC : 'transparent',
+              color: b.primary ? '#fff' : C.ink,
+              border: b.primary ? 'none' : `1.5px solid ${C.borderMid}`,
+              borderRadius: 100, padding: b.primary ? '12px 26px' : '11px 24px',
+              fontSize: 14, fontWeight: 600, fontFamily: 'DM Sans',
+              textDecoration: 'none', display: 'inline-block',
+              transition: 'all 0.2s',
+            }}
+              onMouseEnter={e => { if (b.primary) e.currentTarget.style.opacity = '0.88'; else { e.currentTarget.style.borderColor = ACC; e.currentTarget.style.color = ACC; } }}
+              onMouseLeave={e => { if (b.primary) e.currentTarget.style.opacity = '1'; else { e.currentTarget.style.borderColor = C.borderMid; e.currentTarget.style.color = C.ink; } }}
+            >{b.label}</a>
+          ))}
+        </div>
+      </div>
 
-            <div class="projects-subsection">
-                <h3 class="projects-subsection-title" data-aos="fade-up">Professional Projects</h3>
-                <div class="projects-grid">
-                    <!-- Project 1 -->
-                    <div class="project-card" data-color="purple" data-aos="fade-up">
-                        <div class="project-card-body">
-                            <h3 class="project-title">User Language Prediction Model</h3>
-                            <p class="project-outcome">Built a multilabel language classifier to improve Ads targeting accuracy at Meta, driving $36M incremental ARR by matching ads to users' actual language preferences.</p>
-                            <div class="project-tags">
-                                <span class="tag">Gradient Boosting</span>
-                                <span class="tag">Python</span>
-                                <span class="tag">Ads Targeting</span>
-                                <span class="tag">ML</span>
-                            </div>
-                        </div>
-                        <a href="projects/user-language-model.html" class="project-link">View Project →</a>
-                    </div>
-                    <!-- Project 2 -->
-                    <div class="project-card" data-color="blue" data-aos="fade-up" data-aos-delay="100">
-                        <div class="project-card-body">
-                            <h3 class="project-title">Instagram Shopping Latency Optimization</h3>
-                            <p class="project-outcome">Analyzed and optimized the Instagram Shopping product description page load time, achieving a 40–50% latency reduction, 10% lift in conversions, and $80M ARR for Meta.</p>
-                            <div class="project-tags">
-                                <span class="tag">Product Analytics</span>
-                                <span class="tag">SQL</span>
-                                <span class="tag">Experimentation</span>
-                                <span class="tag">Funnel Analysis</span>
-                            </div>
-                        </div>
-                        <a href="projects/instagram-latency.html" class="project-link">View Project →</a>
-                    </div>
-                </div>
+      {!isMobile && (
+        <div style={{ flex: isTablet ? '0 0 320px' : '0 0 420px', display: 'flex', justifyContent: 'center', alignItems: 'center', position: 'relative', paddingTop: 80 }}>
+          <div style={{ position: 'relative' }}>
+            <img
+              src="https://rohanvartak96.github.io/images/Rohan2.webp"
+              alt="Rohan Vartak"
+              style={{ width: isTablet ? 260 : 340, height: isTablet ? 310 : 400, objectFit: 'cover', objectPosition: 'top', borderRadius: 18, display: 'block', border: `1px solid ${C.border}`, boxShadow: '0 16px 60px rgba(28,24,16,0.13)' }}
+            />
+            <div style={{ position: 'absolute', bottom: -18, left: isTablet ? -16 : -32, background: C.white, border: `1px solid ${C.border}`, borderRadius: 14, padding: '14px 18px', boxShadow: '0 8px 32px rgba(28,24,16,0.12)', minWidth: 170 }}>
+              <div style={{ fontSize: 11, fontWeight: 600, color: C.inkLight, letterSpacing: '0.1em', textTransform: 'uppercase', marginBottom: 6 }}>Impact</div>
+              <div style={{ fontFamily: 'Playfair Display', fontWeight: 800, fontSize: 26, color: C.ink, letterSpacing: '-0.02em', lineHeight: 1 }}>$116M+</div>
+              <div style={{ fontSize: 12, color: C.inkMid, marginTop: 4 }}>ARR at Meta</div>
             </div>
+            <div style={{ position: 'absolute', top: -14, right: isTablet ? -12 : -28, background: ACC, borderRadius: 12, padding: '10px 16px', boxShadow: '0 6px 24px rgba(217,95,43,0.35)' }}>
+              <div style={{ fontSize: 11, fontWeight: 700, color: '#fff', letterSpacing: '0.06em', textTransform: 'uppercase' }}>Meta · IG · Threads</div>
+            </div>
+          </div>
+        </div>
+      )}
 
-            <div class="projects-subsection">
-                <h3 class="projects-subsection-title" data-aos="fade-up">Vibe Coded</h3>
-                <div class="projects-grid">
-                    <!-- Vibe Project 1 -->
-                    <div class="project-card project-card--featured" data-color="emerald" data-aos="fade-up">
-                        <div class="project-card-preview">
-                            <img src="images/App retention curve atlas.png" alt="App Retention Curves Atlas preview">
-                            <div class="preview-overlay">
-                                <a href="https://claude.ai/public/artifacts/85cc15b6-0197-456a-ad02-6390a54a38ba" target="_blank" class="preview-open-btn">
-                                    <i class="fa-solid fa-arrow-up-right-from-square"></i>
-                                    Open App
-                                </a>
-                            </div>
-                        </div>
-                        <div class="project-card-body">
-                            <h3 class="project-title">App Retention Curves Atlas</h3>
-                            <p class="project-outcome">Interactive explorer of 12-month retention benchmarks across 15 app categories — surfacing behavioral patterns, churn drivers, and retention strategies for social, gaming, finance, and more.</p>
-                            <div class="project-tags">
-                                <span class="tag">Data Visualization</span>
-                                <span class="tag">Retention</span>
-                                <span class="tag">Product Analytics</span>
-                            </div>
-                        </div>
-                        <a href="https://claude.ai/public/artifacts/85cc15b6-0197-456a-ad02-6390a54a38ba" target="_blank" class="project-link">Open App →</a>
-                    </div>
-                    <!-- Vibe Project 2 -->
-                    <div class="project-card project-card--featured" data-color="orange" data-aos="fade-up" data-aos-delay="100">
-                        <div class="project-card-preview">
-                            <img src="images/8 bit logo.png" alt="Fire Pixel Editor preview">
-                            <div class="preview-overlay">
-                                <a href="https://claude.ai/public/artifacts/ce616bc7-b327-45a1-a230-3828cbdc5e0f" target="_blank" class="preview-open-btn">
-                                    <i class="fa-solid fa-arrow-up-right-from-square"></i>
-                                    Open App
-                                </a>
-                            </div>
-                        </div>
-                        <div class="project-card-body">
-                            <h3 class="project-title">Fire Pixel Editor</h3>
-                            <p class="project-outcome">A browser-based pixel art editor with a canvas grid, color palette, and drawing tools — built entirely in a single HTML file for instant, zero-install creative sessions.</p>
-                            <div class="project-tags">
-                                <span class="tag">Creative Tool</span>
-                                <span class="tag">Pixel Art</span>
-                                <span class="tag">Interactive</span>
-                            </div>
-                        </div>
-                        <a href="https://claude.ai/public/artifacts/ce616bc7-b327-45a1-a230-3828cbdc5e0f" target="_blank" class="project-link">Open App →</a>
-                    </div>
-                </div>
+      {isMobile && (
+        <div style={{ width: '100%', display: 'flex', justifyContent: 'center', position: 'relative', paddingBottom: 20 }}>
+          <div style={{ position: 'relative' }}>
+            <img
+              src="https://rohanvartak96.github.io/images/Rohan2.webp"
+              alt="Rohan Vartak"
+              style={{ width: Math.min(w - 40, 300), height: Math.min((w - 40) * 1.18, 354), objectFit: 'cover', objectPosition: 'top', borderRadius: 14, display: 'block', border: `1px solid ${C.border}`, boxShadow: '0 8px 32px rgba(28,24,16,0.1)' }}
+            />
+            <div style={{ position: 'absolute', bottom: -14, left: -8, background: C.white, border: `1px solid ${C.border}`, borderRadius: 10, padding: '10px 14px', boxShadow: '0 4px 16px rgba(28,24,16,0.1)' }}>
+              <div style={{ fontSize: 10, fontWeight: 600, color: C.inkLight, letterSpacing: '0.1em', textTransform: 'uppercase', marginBottom: 4 }}>Impact</div>
+              <div style={{ fontFamily: 'Playfair Display', fontWeight: 800, fontSize: 20, color: C.ink, letterSpacing: '-0.02em', lineHeight: 1 }}>$116M+</div>
+              <div style={{ fontSize: 11, color: C.inkMid, marginTop: 3 }}>ARR at Meta</div>
             </div>
-        </section>
-        <!-- SECTION 5: What People Are Saying -->
-        <section id="testimonial-highlights" class="testimonial-highlights reveal">
-            <h2 data-aos="fade-up">What People Are Saying</h2>
-            <div class="highlights-masonry">
-                <div class="highlight-card" data-aos="fade-up">
-                    <div class="testimonial-avatar">CF</div>
-                    <blockquote class="testimonial-quote">He would proactively explore new areas and suggest data-driven directions for our product roadmap, demonstrating his ability to think critically and strategically.</blockquote>
-                    <div class="testimonial-author">
-                        <span class="name">Cristina Fernandez</span>
-                        <span class="separator">—</span>
-                        <span class="position">Product Manager, Meta</span>
-                    </div>
-                </div>
-                <div class="highlight-card" data-aos="fade-up">
-                    <div class="testimonial-avatar">XX</div>
-                    <blockquote class="testimonial-quote">Rohan played a pivotal role in these efforts, conducting in-depth investigations and analyses, and effectively communicating the status and capabilities of the location platform to various stakeholders.</blockquote>
-                    <div class="testimonial-author">
-                        <span class="name">Xiaolu Xiong</span>
-                        <span class="separator">—</span>
-                        <span class="position">Engineering Manager, Meta</span>
-                    </div>
-                </div>
-                <div class="highlight-card" data-aos="fade-up">
-                    <div class="testimonial-avatar">JL</div>
-                    <blockquote class="testimonial-quote">Rohan contributed directly to a significant portion of his team and pillar's goals which would not have been possible without his deep technical insights.</blockquote>
-                    <div class="testimonial-author">
-                        <span class="name">Jenny Lu</span>
-                        <span class="separator">—</span>
-                        <span class="position">Data Science Manager, Meta</span>
-                    </div>
-                </div>
-                <div class="highlight-card" data-aos="fade-up">
-                    <div class="testimonial-avatar">JL</div>
-                    <blockquote class="testimonial-quote">He's the fastest Data Engineer that I had worked with during my almost 5 years at Meta — strong execution and fast turnaround when needed.</blockquote>
-                    <div class="testimonial-author">
-                        <span class="name">Jessie Li</span>
-                        <span class="separator">—</span>
-                        <span class="position">Data Science, OpenAI</span>
-                    </div>
-                </div>
-                <div class="highlight-card" data-aos="fade-up">
-                    <div class="testimonial-avatar">GS</div>
-                    <blockquote class="testimonial-quote">Rohan consistently works well across the functions of product management, software engineering, and data engineering in order to land collaborative, influential product enhancements.</blockquote>
-                    <div class="testimonial-author">
-                        <span class="name">George Schick</span>
-                        <span class="separator">—</span>
-                        <span class="position">Data Science Manager, Netflix</span>
-                    </div>
-                </div>
-                <div class="highlight-card" data-aos="fade-up">
-                    <div class="testimonial-avatar">AD</div>
-                    <blockquote class="testimonial-quote">Rohan was an idea guy and it was evident in team meetings and brainstorming sessions when his suggestions helped others in building their product.</blockquote>
-                    <div class="testimonial-author">
-                        <span class="name">Aditya Dasnurkar</span>
-                        <span class="separator">—</span>
-                        <span class="position">Data Engineering Manager, Meta</span>
-                    </div>
-                </div>
-                <div class="highlight-card" data-aos="fade-up">
-                    <div class="testimonial-avatar">JZ</div>
-                    <blockquote class="testimonial-quote">He doesn't just deliver data — he distills complex technical insights into actionable summaries that move the needle. Rohan would be a massive asset to any team looking for a senior-level DS who can navigate ambiguity and drive clear, measurable product impact.</blockquote>
-                    <div class="testimonial-author">
-                        <span class="name">Jessica Zhou</span>
-                        <span class="separator">—</span>
-                        <span class="position">Staff Data Scientist, Meta</span>
-                    </div>
-                </div>
-                <div class="highlight-card" data-aos="fade-up">
-                    <div class="testimonial-avatar">AJ</div>
-                    <blockquote class="testimonial-quote">Rohan showcased strong ownership of data artifacts, distinctly addressed the needs of his cross-functional partners, and demonstrated a strong product sense — quickly conceptualizing and building a robust data foundation for new products.</blockquote>
-                    <div class="testimonial-author">
-                        <span class="name">Apoorvi Jain</span>
-                        <span class="separator">—</span>
-                        <span class="position">Director, Meta AI Wearables Data Engineering</span>
-                    </div>
-                </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function AboutStrip() {
+  const C = useC();
+  const ref = useRef(null);
+  const visible = useInView(ref);
+  const w = useWindowWidth();
+  const isMobile = w < 768;
+  return (
+    <section ref={ref} style={{ padding: `${isMobile ? 48 : 64}px ${hPad(w)}`, background: C.creamDark, display: 'flex', gap: isMobile ? 20 : 64, alignItems: isMobile ? 'flex-start' : 'center', flexWrap: 'wrap', flexDirection: isMobile ? 'column' : 'row', opacity: visible ? 1 : 0, transform: visible ? 'none' : 'translateY(20px)', transition: 'all 0.6s ease' }}>
+      <p style={{ fontSize: 11, fontWeight: 600, color: C.inkLight, letterSpacing: '0.18em', textTransform: 'uppercase', flex: '0 0 auto' }}>Currently</p>
+      <p style={{ fontFamily: 'Playfair Display', fontWeight: 700, fontSize: isMobile ? 18 : 20, color: C.ink, lineHeight: 1.4, flex: isMobile ? '0 0 auto' : '1 1 280px' }}>
+        "Full-stack data scientist at the intersection of ML and Product Analytics. Building systems that serve <span style={{ fontStyle: 'italic', color: ACC }}>billions of users.</span>"
+      </p>
+      <div style={{ display: 'flex', gap: isMobile ? 16 : 24, flex: '0 0 auto', flexWrap: 'wrap' }}>
+        {['Meta','Instagram','Threads'].map(co => (
+          <div key={co} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <div style={{ width: 8, height: 8, borderRadius: '50%', background: ACC }}></div>
+            <span style={{ fontSize: 13, fontWeight: 500, color: C.inkMid }}>{co}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+const PROJECTS = [
+  {
+    num: '01', type: 'professional', category: 'ML Engineering',
+    title: 'User Language Prediction Model',
+    desc: "Built a multilabel language classifier to improve Ads targeting accuracy at Meta, driving $36M incremental ARR by matching ads to users' actual language preferences.",
+    impact: '$36M ARR', tags: ['Gradient Boosting','Python','Ads Targeting','ML'],
+    href: 'projects/user-language-model.html',
+  },
+  {
+    num: '02', type: 'professional', category: 'Product Analytics',
+    title: 'Instagram Shopping Latency Optimization',
+    desc: 'Analyzed and optimized the Instagram Shopping product description page, achieving a 40–50% latency reduction, 10% lift in conversions, and $80M ARR.',
+    impact: '$80M ARR', tags: ['Product Analytics','SQL','Experimentation','Funnel Analysis'],
+    href: 'projects/instagram-latency.html',
+  },
+  {
+    num: '03', type: 'personal', category: 'Data Visualization',
+    title: 'App Retention Curves Atlas',
+    desc: 'Interactive explorer of 12-month retention benchmarks across 15 app categories — surfacing behavioral patterns, churn drivers, and strategies.',
+    impact: 'Open Source', tags: ['Data Viz','Retention','Product Analytics'],
+    href: 'https://claude.ai/public/artifacts/85cc15b6-0197-456a-ad02-6390a54a38ba',
+    image: 'https://rohanvartak96.github.io/images/App retention curve atlas.png',
+  },
+  {
+    num: '04', type: 'personal', category: 'Creative Tool',
+    title: 'Fire Pixel Editor',
+    desc: 'A browser-based pixel art editor with canvas grid, color palette, and drawing tools — built entirely in a single HTML file for zero-install creative sessions.',
+    impact: 'Vibe Coded', tags: ['Creative Tool','Pixel Art','Interactive'],
+    href: 'https://claude.ai/public/artifacts/ce616bc7-b327-45a1-a230-3828cbdc5e0f',
+    image: 'https://rohanvartak96.github.io/images/8 bit logo.png',
+  },
+];
+
+function ProjectCard({ project }) {
+  const C = useC();
+  const [hovered, setHovered] = useState(false);
+  const isExternal = project.href.startsWith('http');
+  return (
+    <a href={project.href} target={isExternal ? '_blank' : undefined} rel={isExternal ? 'noopener noreferrer' : undefined}
+      style={{ background: hovered ? C.white : C.creamCard, border: `1px solid ${C.border}`, borderRadius: 14, overflow: 'hidden', display: 'flex', flexDirection: 'column', transition: 'background 0.2s, box-shadow 0.2s, transform 0.2s', boxShadow: hovered ? '0 12px 40px rgba(28,24,16,0.12)' : '0 2px 8px rgba(28,24,16,0.04)', transform: hovered ? 'translateY(-3px)' : 'none', cursor: 'pointer', textDecoration: 'none' }}
+      onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}
+    >
+      {project.image && (
+        <div style={{ width: '100%', height: 180, overflow: 'hidden', background: C.creamCard, flexShrink: 0, position: 'relative' }}>
+          <img src={project.image} alt={project.title} style={{ width: '100%', height: '100%', objectFit: 'cover', objectPosition: 'top', transition: 'transform 0.4s ease', transform: hovered ? 'scale(1.04)' : 'scale(1)' }} />
+          <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(to bottom, transparent 50%, rgba(28,24,16,0.18) 100%)' }}></div>
+        </div>
+      )}
+      <div style={{ padding: '24px 24px 20px', display: 'flex', flexDirection: 'column', flex: 1 }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 10, flexWrap: 'wrap', gap: '6px 8px' }}>
+          <p style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.16em', textTransform: 'uppercase', color: C.inkLight, flex: '1 1 auto', minWidth: 0 }}>{project.category}</p>
+          <span style={{ background: ACC, color: '#fff', borderRadius: 100, padding: '4px 12px', fontSize: 11, fontWeight: 700, letterSpacing: '0.04em', flexShrink: 0, whiteSpace: 'nowrap' }}>{project.impact}</span>
+        </div>
+        <h3 style={{ fontFamily: 'Playfair Display', fontWeight: 800, fontSize: 20, lineHeight: 1.2, color: C.ink, marginBottom: 12, letterSpacing: '-0.01em' }}>{project.title}</h3>
+        <p style={{ fontSize: 13.5, lineHeight: 1.65, color: C.inkMid, marginBottom: 18 }}>{project.desc}</p>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 20 }}>
+          {project.tags.map(t => <span key={t} style={{ background: `${ACC}15`, color: ACC, border: `1px solid ${ACC}30`, borderRadius: 100, padding: '3px 10px', fontSize: 11, fontWeight: 500 }}>{t}</span>)}
+        </div>
+        <span style={{ fontFamily: 'DM Sans', fontSize: 13, fontWeight: 600, color: ACC, marginTop: 'auto' }}>View Project →</span>
+      </div>
+    </a>
+  );
+}
+
+function Projects() {
+  const C = useC();
+  const ref = useRef(null);
+  const visible = useInView(ref);
+  const w = useWindowWidth();
+  const isMobile = w < 768;
+  const professional = PROJECTS.filter(p => p.type === 'professional');
+  const personal = PROJECTS.filter(p => p.type === 'personal');
+
+  const subHeadStyle = {
+    fontFamily: 'DM Sans', fontWeight: 700, fontSize: 13,
+    letterSpacing: '0.12em', textTransform: 'uppercase',
+    color: C.inkLight, marginBottom: 20, marginTop: 48,
+    display: 'flex', alignItems: 'center', gap: 12,
+  };
+  const subLineStyle = { flex: 1, height: 1, background: C.border };
+
+  return (
+    <section id="projects" ref={ref} style={{ padding: `96px ${hPad(w)}`, background: C.cream, opacity: visible ? 1 : 0, transform: visible ? 'none' : 'translateY(20px)', transition: 'all 0.6s ease' }}>
+      <Eyebrow>Work &amp; Side Projects</Eyebrow>
+      <SectionHeading plain="Selected" italic="projects." />
+
+      <div style={subHeadStyle}>
+        <span>Professional Projects</span>
+        <div style={subLineStyle}></div>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : 'repeat(auto-fit, minmax(340px, 1fr))', gap: isMobile ? 16 : 20 }}>
+        {professional.map(p => <ProjectCard key={p.title} project={p} />)}
+      </div>
+
+      <div style={subHeadStyle}>
+        <span>Personal Projects</span>
+        <div style={subLineStyle}></div>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : 'repeat(auto-fit, minmax(340px, 1fr))', gap: isMobile ? 16 : 20 }}>
+        {personal.map(p => <ProjectCard key={p.title} project={p} />)}
+      </div>
+    </section>
+  );
+}
+
+const SKILLS = [
+  { num: '01', title: 'ML Engineering', desc: 'Building and shipping production ML models — classifiers, rankers, embeddings — at Meta scale. From feature engineering to A/B tested rollouts.' },
+  { num: '02', title: 'Product Analytics', desc: 'Defining metrics, running experiments, and building dashboards that translate user behavior into product decisions with measurable business impact.' },
+  { num: '03', title: 'AI Systems', desc: 'Designing and prototyping AI agents, RAG pipelines, and LLM-powered tools that solve real user problems — fast, scrappy, and shipped.' },
+];
+
+function SkillRow({ s, idx }) {
+  const C = useC();
+  const ref = useRef(null);
+  const visible = useInView(ref);
+  const w = useWindowWidth();
+  const isMobile = w < 768;
+  return (
+    <div ref={ref} style={{
+      display: 'grid',
+      gridTemplateColumns: isMobile ? '1fr' : '56px 1fr 1fr',
+      gap: isMobile ? 12 : 40,
+      padding: isMobile ? '36px 0' : '52px 0',
+      borderBottom: `1px solid ${C.border}`,
+      alignItems: 'start',
+      opacity: visible ? 1 : 0,
+      transform: visible ? 'none' : 'translateY(20px)',
+      transition: `all 0.55s ease ${idx * 0.1}s`,
+    }}>
+      {isMobile ? (
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 10 }}>
+            <span style={{ fontFamily: 'DM Sans', fontWeight: 700, fontSize: 12, color: C.inkLight }}>{s.num}</span>
+            <h3 style={{ fontFamily: 'Playfair Display', fontWeight: 800, fontSize: 24, color: C.ink, lineHeight: 1.15, letterSpacing: '-0.02em' }}>{s.title}</h3>
+          </div>
+          <p style={{ fontSize: 15, lineHeight: 1.7, color: C.inkMid }}>{s.desc}</p>
+        </div>
+      ) : (
+        <>
+          <span style={{ fontFamily: 'DM Sans', fontWeight: 700, fontSize: 13, color: C.inkLight, paddingTop: 4 }}>{s.num}</span>
+          <h3 style={{ fontFamily: 'Playfair Display', fontWeight: 800, fontSize: 28, color: C.ink, lineHeight: 1.15, letterSpacing: '-0.02em' }}>{s.title}</h3>
+          <p style={{ fontSize: 15, lineHeight: 1.7, color: C.inkMid }}>{s.desc}</p>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Skills() {
+  const C = useC();
+  const w = useWindowWidth();
+  return (
+    <section id="skills" style={{ padding: `96px ${hPad(w)}`, background: C.creamDark }}>
+      <Eyebrow>What I Do</Eyebrow>
+      <SectionHeading plain="Three capabilities," italic="one toolkit." />
+      <div style={{ marginTop: 12, borderTop: `1px solid ${C.border}` }}>
+        {SKILLS.map((s,i) => <SkillRow key={s.num} s={s} idx={i} />)}
+      </div>
+    </section>
+  );
+}
+
+function StatStrip() {
+  const dark = React.useContext(ThemeCtx);
+  const ref = useRef(null);
+  const visible = useInView(ref);
+  const w = useWindowWidth();
+  const isMobile = w < 768;
+  const v1 = useCounter(36, visible, 1200);
+  const v2 = useCounter(80, visible, 1400);
+  const v3 = useCounter(50, visible, 1600);
+  const v4 = useCounter(10, visible, 1000);
+
+  const stats = [
+    { val: `$${v1}M`, label: 'ARR from Language Model', sub: 'Meta Ads' },
+    { val: `$${v2}M`, label: 'ARR from Latency Fix', sub: 'Instagram Shopping' },
+    { val: `${v3}%`, label: 'Latency Reduction', sub: 'Page load time' },
+    { val: `${v4}%`, label: 'Conversion Lift', sub: 'Instagram Shopping' },
+  ];
+
+  return (
+    <section ref={ref} style={{ padding: `${isMobile ? 48 : 80}px ${hPad(w)}`, background: dark ? '#0D0B09' : '#1C1810' }}>
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: isMobile ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)',
+        gap: isMobile ? 0 : 0,
+        borderLeft: '1px solid rgba(255,255,255,0.08)',
+      }}>
+        {stats.map((s,i) => (
+          <div key={i} style={{
+            padding: isMobile ? '24px 16px' : '0 40px',
+            borderRight: '1px solid rgba(255,255,255,0.08)',
+            borderBottom: isMobile && i < 2 ? '1px solid rgba(255,255,255,0.08)' : 'none',
+          }}>
+            <div style={{ fontFamily: 'Playfair Display', fontWeight: 900, fontSize: isMobile ? 36 : 52, color: ACC, lineHeight: 1, letterSpacing: '-0.03em', marginBottom: isMobile ? 6 : 10 }}>{s.val}</div>
+            <div style={{ fontSize: isMobile ? 12 : 14, fontWeight: 500, color: 'rgba(255,255,255,0.85)', marginBottom: 4 }}>{s.label}</div>
+            <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.4)', letterSpacing: '0.05em' }}>{s.sub}</div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+const TESTIMONIALS = [
+  { initials: 'JZ', name: 'Jessica Zhou', role: 'Staff Data Scientist, Meta', quote: "He doesn't just deliver data — he distills complex technical insights into actionable summaries that move the needle. A massive asset to any team looking for a senior-level DS." },
+  { initials: 'CF', name: 'Cristina Fernandez', role: 'Product Manager, Meta', quote: 'He would proactively explore new areas and suggest data-driven directions for our product roadmap, demonstrating his ability to think critically and strategically.' },
+  { initials: 'GS', name: 'George Schick', role: 'Data Science Manager, Netflix', quote: 'Rohan consistently works well across product management, software engineering, and data engineering in order to land collaborative, influential product enhancements.' },
+  { initials: 'JL', name: 'Jessie Li', role: 'Data Science, OpenAI', quote: "He's the fastest Data Engineer I had worked with during my almost 5 years at Meta — strong execution and fast turnaround when needed." },
+  { initials: 'AJ', name: 'Apoorvi Jain', role: 'Director, Meta AI Wearables', quote: 'Rohan showcased strong ownership, distinctly addressed the needs of his cross-functional partners, and demonstrated a strong product sense — quickly building a robust data foundation for new products.' },
+  { initials: 'XX', name: 'Xiaolu Xiong', role: 'Engineering Manager, Meta', quote: 'Rohan played a pivotal role conducting in-depth investigations and analyses, and effectively communicating the status and capabilities of the location platform to various stakeholders.' },
+  { initials: 'JL2', name: 'Jenny Lu', role: 'Data Science Manager, Meta', quote: "Rohan contributed directly to a significant portion of his team and pillar's goals which would not have been possible without his deep technical insights." },
+  { initials: 'AD', name: 'Aditya Dasnurkar', role: 'Data Engineering Manager, Meta', quote: 'Rohan was an idea guy and it was evident in team meetings and brainstorming sessions when his suggestions helped others in building their product.' },
+];
+
+function TestiCard({ t, delay }) {
+  const C = useC();
+  const ref = useRef(null);
+  const visible = useInView(ref);
+  const [hov, setHov] = useState(false);
+  return (
+    <div ref={ref} style={{
+      background: hov ? C.white : C.cream,
+      border: `1px solid ${C.border}`,
+      borderRadius: 14, padding: '24px',
+      display: 'flex', flexDirection: 'column', gap: 16,
+      transition: visible
+        ? 'background 0.2s, box-shadow 0.2s, transform 0.2s, opacity 0.55s'
+        : `background 0.2s, box-shadow 0.2s, transform 0.55s ${delay}s, opacity 0.55s ${delay}s`,
+      boxShadow: hov ? '0 12px 40px rgba(28,24,16,0.12)' : '0 2px 8px rgba(28,24,16,0.04)',
+      transform: hov ? 'translateY(-3px)' : visible ? 'none' : 'translateY(16px)',
+      breakInside: 'avoid', marginBottom: 16,
+      opacity: visible ? 1 : 0,
+    }}
+      onMouseEnter={() => setHov(true)} onMouseLeave={() => setHov(false)}
+    >
+      <p style={{ fontFamily: 'DM Sans', fontSize: 14, fontWeight: 400, lineHeight: 1.7, color: C.inkMid, flex: 1 }}>{t.quote}</p>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, borderTop: `1px solid ${C.border}`, paddingTop: 14 }}>
+        <div style={{ width: 34, height: 34, borderRadius: 8, background: ACC, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'DM Sans', fontWeight: 700, fontSize: 12, color: '#fff', flexShrink: 0 }}>{t.initials.replace('2','')}</div>
+        <div>
+          <div style={{ fontSize: 13, fontWeight: 600, color: C.ink }}>{t.name}</div>
+          <div style={{ fontSize: 11, color: C.inkLight }}>{t.role}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Testimonials() {
+  const C = useC();
+  const dark = React.useContext(ThemeCtx);
+  const w = useWindowWidth();
+  const isMobile = w < 640;
+  const isTablet = w < 960;
+  const cols = isMobile ? '1' : isTablet ? '2' : '320px 3';
+  return (
+    <section id="testimonials" style={{ padding: `${isMobile ? 64 : 96}px ${hPad(w)}`, background: 'linear-gradient(160deg, #c93a06 0%, #decbc3 100%)', position: 'relative', overflow: 'hidden' }}>
+      <div style={{ position: 'absolute', top: '-20%', right: '-5%', width: isMobile ? 300 : 600, height: isMobile ? 300 : 600, borderRadius: '50%', background: `radial-gradient(circle, ${ACC}18 0%, transparent 70%)`, pointerEvents: 'none' }}></div>
+      <div style={{ position: 'absolute', bottom: '-20%', left: '5%', width: isMobile ? 200 : 400, height: isMobile ? 200 : 400, borderRadius: '50%', background: `radial-gradient(circle, ${ACC}0d 0%, transparent 70%)`, pointerEvents: 'none' }}></div>
+      <div style={{ position: 'relative' }}>
+        <Eyebrow style={{ color: 'rgba(255,255,255,0.5)' }}>Colleagues &amp; Managers</Eyebrow>
+        <h2 style={{ fontFamily: 'Playfair Display, serif', fontWeight: 900, fontSize: 'clamp(28px, 4vw, 54px)', letterSpacing: '-0.025em', color: C.ink, lineHeight: 1.0, marginBottom: 0 }}>
+          What people <span style={{ fontStyle: 'italic', color: '#fff' }}>are saying.</span>
+        </h2>
+        <div style={{ columns: cols, columnGap: 16, marginTop: 48 }}>
+          {TESTIMONIALS.map((t,i) => <TestiCard key={i} t={t} delay={i * 0.05} />)}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Contact() {
+  const C = useC();
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [sent, setSent] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState('');
+  const w = useWindowWidth();
+  const isMobile = w < 768;
+
+  const inp = { width: '100%', background: 'transparent', border: 'none', borderBottom: `1.5px solid ${C.border}`, padding: '10px 0', fontSize: 15, fontFamily: 'DM Sans', color: C.ink, outline: 'none', marginBottom: 24, transition: 'border-color 0.2s' };
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    setSending(true);
+    setError('');
+    fetch('https://formsubmit.co/ajax/rohanvartak1996@gmail.com', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+      body: JSON.stringify({ name, email, message }),
+    })
+      .then(res => res.json())
+      .then(data => {
+        if (data.success === 'true' || data.success === true) {
+          setSent(true);
+        } else {
+          setError('Something went wrong. Please try again.');
+        }
+      })
+      .catch(() => setError('Something went wrong. Please try again.'))
+      .finally(() => setSending(false));
+  }
+
+  return (
+    <section id="contact" style={{ padding: `${isMobile ? 64 : 96}px ${hPad(w)}`, background: C.creamDark }}>
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr',
+        gap: isMobile ? 40 : 80,
+        alignItems: 'start',
+      }}>
+        <div>
+          <p style={{ fontFamily: 'DM Sans', fontSize: 11, fontWeight: 500, letterSpacing: '0.18em', textTransform: 'uppercase', color: C.inkLight, marginBottom: 10 }}>Let's work together</p>
+          <h2 style={{ fontFamily: 'Playfair Display, serif', fontWeight: 900, fontSize: 'clamp(32px, 4vw, 52px)', letterSpacing: '-0.02em', color: C.ink, lineHeight: 1.05, marginBottom: 20 }}>
+            Have a project <span style={{ fontStyle: 'italic', color: ACC }}>in mind?</span>
+          </h2>
+          <p style={{ fontFamily: 'DM Sans', fontSize: 15, color: C.inkMid, lineHeight: 1.65, marginBottom: 40 }}>
+            Open to Senior ML / Data Science roles at product-led companies. Feel free to reach out.
+          </p>
+        </div>
+        <div>
+          <form onSubmit={handleSubmit}>
+              <input style={inp} placeholder="Your name" value={name} onChange={e => setName(e.target.value)} required onFocus={e => e.target.style.borderBottomColor = ACC} onBlur={e => e.target.style.borderBottomColor = C.border} />
+              <input style={inp} type="email" placeholder="Email address" value={email} onChange={e => setEmail(e.target.value)} required onFocus={e => e.target.style.borderBottomColor = ACC} onBlur={e => e.target.style.borderBottomColor = C.border} />
+              <textarea style={{ ...inp, resize: 'none', height: 120, display: 'block' }} placeholder="Your message" value={message} onChange={e => setMessage(e.target.value)} required onFocus={e => e.target.style.borderBottomColor = ACC} onBlur={e => e.target.style.borderBottomColor = C.border}></textarea>
+              {error && <p style={{ fontFamily: 'DM Sans', fontSize: 13, color: '#c0392b', marginBottom: 12, marginTop: -12 }}>{error}</p>}
+              <button type="submit" disabled={sending} style={{ background: ACC, color: '#fff', border: 'none', borderRadius: 100, padding: '13px 32px', fontSize: 15, fontWeight: 600, cursor: sending ? 'not-allowed' : 'pointer', fontFamily: 'DM Sans', transition: 'opacity 0.2s', marginTop: 8, opacity: sending ? 0.65 : 1 }}
+                onMouseEnter={e => { if (!sending) e.target.style.opacity = '0.85'; }}
+                onMouseLeave={e => { if (!sending) e.target.style.opacity = '1'; }}
+              >{sending ? 'Sending…' : 'Send Message →'}</button>
+            </form>
+          {sent && (
+            <div style={{ background: `${ACC}15`, border: `1px solid ${ACC}40`, borderRadius: 12, padding: '16px 20px', fontFamily: 'DM Sans', color: C.ink, marginTop: 20 }}>
+              <strong>Message sent!</strong> I'll get back to you soon.
             </div>
-        </section>
-        <!-- SECTION 5: Contact -->
-        <section id="contact" class="contact-section reveal">
-            <div class="contact-inner">
-                <div class="contact-left" data-aos="fade-up">
-                    <p class="section-eyebrow">Contact</p>
-                    <h2 class="contact-heading">Have a project in mind or want to collaborate?</h2>
-                    <p class="contact-subheading">Get in touch!</p>
-                    <div class="contact-social">
-                        <p class="connect-label">Connect with me</p>
-                        <div class="social-links">
-                            <a href="https://www.linkedin.com/in/rohanvartak1996/" target="_blank"><i class="fa-brands fa-linkedin"></i></a>
-                            <a href="mailto:rohanvartak1996@gmail.com"><i class="fa-solid fa-envelope"></i></a>
-                        </div>
-                    </div>
-                </div>
-                <div class="contact-right" data-aos="fade-up" data-aos-delay="100">
-                    <form action="https://formsubmit.co/4dd1a833f16e0b34369ba36dd21ff0d1" method="POST">
-                        <input type="text" name="_honey" style="display:none;">
-                        <input type="hidden" name="_captcha" value="false">
-                        <input type="text" name="name" id="name" placeholder="Your Name" required>
-                        <input type="email" name="email" id="email" placeholder="Your Email" required>
-                        <textarea id="message" name="message" rows="6" placeholder="Your Message" required></textarea>
-                        <button type="submit">Send Message</button>
-                    </form>
-                </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Footer() {
+  const dark = React.useContext(ThemeCtx);
+  const w = useWindowWidth();
+  const isMobile = w < 640;
+  return (
+    <footer style={{ background: dark ? '#0D0B09' : '#1C1810', padding: `${isMobile ? 48 : 56}px ${hPad(w)} ${isMobile ? 24 : 32}px` }}>
+      <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : '2fr 1fr 1fr 1fr', gap: isMobile ? 32 : 40, paddingBottom: isMobile ? 32 : 48, borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+        <div style={{ gridColumn: isMobile ? '1 / -1' : 'auto' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16 }}>
+            <div style={{ width: 28, height: 28, borderRadius: 6, background: ACC, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'Playfair Display', fontWeight: 900, fontSize: 13, color: '#fff' }}>R</div>
+            <span style={{ fontFamily: 'DM Sans', fontWeight: 600, fontSize: 14, color: '#fff' }}>Rohan Vartak</span>
+          </div>
+          <p style={{ fontSize: 13, color: 'rgba(255,255,255,0.45)', lineHeight: 1.65, maxWidth: 240 }}>A data scientist on every team — building ML models that move the needle.</p>
+        </div>
+        {[
+          { label: 'Work', links: [['Projects','#projects'],['Skills','#skills'],['Resume','resume.html']] },
+          { label: 'Social', links: [['LinkedIn','https://www.linkedin.com/in/rohanvartak1996/'],['GitHub','https://github.com/rohanvartak96']] },
+          { label: 'Contact', links: [['Get in Touch','#contact']] },
+        ].map(col => (
+          <div key={col.label}>
+            <p style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.3)', marginBottom: 16 }}>{col.label}</p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {col.links.map(([label, href]) => (
+                <a key={label} href={href} style={{ fontSize: 13, color: 'rgba(255,255,255,0.6)', textDecoration: 'none', transition: 'color 0.2s' }}
+                  onMouseEnter={e => e.target.style.color = ACC}
+                  onMouseLeave={e => e.target.style.color = 'rgba(255,255,255,0.6)'}
+                >{label}</a>
+              ))}
             </div>
-        </section>
-        <!-- SECTION 6: Footer -->
-        <footer class="footer-section">
-            <p>Designed by Rohan Vartak &copy; 2025</p>
-            <div class="footer-links">
-                <a href="https://www.linkedin.com/in/rohanvartak1996/" target="_blank"><i
-                        class="fa-brands fa-linkedin"></i></a>
-                <a href="mailto:rohanvartak1996@gmail.com"><i class="fa-solid fa-envelope"></i></a>
-            </div>
-        </footer>
-    </main>
-    <!-- AOS -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function () {
-            AOS.init({ duration: 500, once: true, offset: 80 });
-        });
-    </script>
-    <button id="back-to-top" aria-label="Back to top">
-        <i class="fa-solid fa-chevron-up"></i>
-    </button>
+          </div>
+        ))}
+      </div>
+      <div style={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', justifyContent: 'space-between', alignItems: isMobile ? 'flex-start' : 'center', paddingTop: 24, gap: isMobile ? 8 : 0 }}>
+        <span style={{ fontSize: 12, color: 'rgba(255,255,255,0.3)' }}>Designed by Rohan Vartak © 2025</span>
+        <a href="mailto:rohanvartak1996@gmail.com" style={{ fontSize: 12, color: 'rgba(255,255,255,0.3)', textDecoration: 'none', transition: 'color 0.2s' }}
+          onMouseEnter={e => e.target.style.color = ACC}
+          onMouseLeave={e => e.target.style.color = 'rgba(255,255,255,0.3)'}
+        >rohanvartak1996@gmail.com</a>
+      </div>
+    </footer>
+  );
+}
+
+function Eyebrow({ children, style }) {
+  const C = useC();
+  return <p style={{ fontFamily: 'DM Sans', fontSize: 11, fontWeight: 500, letterSpacing: '0.18em', textTransform: 'uppercase', color: C.inkLight, marginBottom: 14, ...style }}>{children}</p>;
+}
+function SectionHeading({ plain, italic, light }) {
+  const C = useC();
+  return (
+    <h2 style={{ fontFamily: 'Playfair Display, serif', fontWeight: 900, fontSize: 'clamp(28px, 4vw, 54px)', letterSpacing: '-0.025em', color: light ? '#fff' : C.ink, lineHeight: 1.0, marginBottom: 0 }}>
+      {plain} <span style={{ fontStyle: 'italic', color: ACC }}>{italic}</span>
+    </h2>
+  );
+}
+
+function App() {
+  const [dark, setDark] = useState(() => { try { return localStorage.getItem('theme') === 'dark'; } catch(e) { return false; } });
+
+  useEffect(() => {
+    try { localStorage.setItem('theme', dark ? 'dark' : 'light'); } catch(e) {}
+    document.documentElement.classList.toggle('dark', dark);
+  }, [dark]);
+
+  useEffect(() => {
+    const hash = window.location.hash;
+    if (!hash) return;
+    requestAnimationFrame(() => {
+      const el = document.querySelector(hash);
+      if (el) el.scrollIntoView({ behavior: 'instant' });
+    });
+  }, []);
+
+  const bg = dark ? CD.cream : C.cream;
+  return (
+    <ThemeCtx.Provider value={dark}>
+      <div style={{ background: bg, transition: 'background 0.25s ease' }}>
+        <Nav dark={dark} setDark={setDark} />
+        <Hero />
+        <AboutStrip />
+        <StatStrip />
+        <Projects />
+        <Skills />
+        <Testimonials />
+        <Contact />
+        <Footer />
+      </div>
+    </ThemeCtx.Provider>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+</script>
 </body>
-
 </html>

--- a/projects/instagram-latency.html
+++ b/projects/instagram-latency.html
@@ -1,152 +1,420 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
-        integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg=="
-        crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.css" />
-
-    <title>Instagram Shopping Latency Optimization | Rohan Vartak</title>
-    <meta name="description" content="Optimized Instagram Shopping page load time, achieving 40–50% latency reduction, 10% conversion lift, and $80M ARR.">
-    <meta property="og:title" content="Instagram Shopping Latency Optimization | Rohan Vartak">
-    <meta property="og:description" content="Optimized Instagram Shopping page load time, achieving 40–50% latency reduction, 10% conversion lift, and $80M ARR.">
-    <meta property="og:image" content="https://rohanvartak96.github.io/images/Rohan2.webp">
-    <meta property="og:url" content="https://rohanvartak96.github.io/projects/instagram-latency.html">
-
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🚀</text></svg>">
-    <link rel="stylesheet" href="projects.css">
-    <script src="../script.js" defer></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Instagram Shopping Latency Optimization | Rohan Vartak</title>
+<meta name="description" content="How Rohan cut Instagram Shopping latency by 45% and drove $80M ARR through funnel analysis and experimentation.">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='18' fill='%23D95F2B'/><text x='50' y='76' font-family='Playfair Display,serif' font-weight='900' font-size='68' fill='%23fff' text-anchor='middle'>R</text></svg>">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;0,800;0,900;1,700;1,800&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600;9..40,700;9..40,800&display=swap" rel="stylesheet">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<style>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
+body { background: #F4EFE6; color: #1C1810; font-family: 'DM Sans', sans-serif; -webkit-font-smoothing: antialiased; transition: background 0.25s ease, color 0.25s ease; }
+html.dark body { background: #1C1A17; color: #F0EBE1; }
+::selection { background: #D95F2B; color: #fff; }
+</style>
+<script>(function(){try{if(localStorage.getItem('theme')==='dark')document.documentElement.classList.add('dark');}catch(e){}})()</script>
 </head>
-
 <body>
-    <header class="navbar-outer">
-        <nav>
-            <div class="left">
-                <a href="../index.html">🚀 Rohan Vartak</a>
-            </div>
-            <div class="right">
-                <div class="nav-links" id="nav-links">
-                    <a href="../index.html#projects" class="nav-link">Projects</a>
-                    <a href="../index.html#testimonial-highlights" class="nav-link">Testimonials</a>
-                    <a href="../resume.html" class="nav-link">Resume</a>
-                    <a href="../index.html#contact" class="nav-link nav-link--cta">
-                        <i class="fa-solid fa-envelope"></i>
-                        <span>Contact</span>
-                    </a>
-                </div>
-                <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                </button>
-            </div>
-        </nav>
-    </header>
+<div id="root"></div>
+<script type="text/babel">
+const { useState, useEffect, useRef } = React;
 
-    <main>
-        <!-- Project Hero -->
-        <section class="project-hero">
-            <a href="../index.html#projects" class="back-link">← Back to Projects</a>
-            <h1>Instagram Shopping Latency Optimization</h1>
-            <p class="impact-statement">Answered a director-level question on latency ROI through deep funnel analysis — identifying and driving experiments that cut page load time by 40–50%, translating to a 10% lift in conversions and $80M ARR.</p>
-            <div class="tag-row">
-                <span class="tag">Product Analytics</span>
-                <span class="tag">SQL</span>
-                <span class="tag">Experimentation</span>
-                <span class="tag">Funnel Analysis</span>
-            </div>
-        </section>
+const ACC = '#D95F2B';
+const C = {
+  cream: '#F4EFE6', creamDark: '#EDE5D8', creamCard: '#EAE3D5',
+  white: '#FFFFFF', ink: '#1C1810', inkMid: '#4A3F32', inkLight: '#8A7E70',
+  border: 'rgba(28,24,16,0.11)', borderMid: 'rgba(28,24,16,0.18)',
+};
+const CD = {
+  cream: '#1C1A17', creamDark: '#232019', creamCard: '#2B2722',
+  white: '#332E28', ink: '#F0EBE1', inkMid: '#B5A99A', inkLight: '#7A7065',
+  border: 'rgba(240,235,225,0.09)', borderMid: 'rgba(240,235,225,0.14)',
+};
+const ThemeCtx = React.createContext(false);
+function useC() { const dark = React.useContext(ThemeCtx); return dark ? CD : C; }
 
-        <!-- Project Content -->
-        <div class="project-content">
+function useInView(ref, threshold = 0.1) {
+  const [v, setV] = useState(false);
+  useEffect(() => {
+    if (!ref.current) return;
+    const obs = new IntersectionObserver(([e]) => { if (e.isIntersecting) { setV(true); obs.disconnect(); } }, { threshold });
+    obs.observe(ref.current);
+    return () => obs.disconnect();
+  }, []);
+  return v;
+}
 
-            <!-- Overview -->
-            <div class="project-section" data-aos="fade-up">
-                <h2>Overview</h2>
-                <p>Instagram has a native in-app shopping flow integrated with Ads, allowing users to browse and purchase products without leaving the app. My team owned the latency of the Product Description Page (PDP) — the core page in the shopping funnel where users decide whether to convert.</p>
-                <p><strong>Role &amp; Scope:</strong> The Director of the Ads org asked a direct question: what is the ROI on maintaining latency? I structured and led the full analysis to answer it, then identified the highest-impact engineering improvements and drove two experiments to production.</p>
-            </div>
+function useCounter(target, visible, duration = 1200) {
+  const [val, setVal] = useState(0);
+  useEffect(() => {
+    if (!visible) return;
+    let start = null;
+    const step = ts => {
+      if (!start) start = ts;
+      const p = Math.min((ts - start) / duration, 1);
+      setVal(Math.round((1 - Math.pow(1 - p, 3)) * target));
+      if (p < 1) requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+  }, [visible, target]);
+  return val;
+}
 
-            <!-- Approach -->
-            <div class="project-section" data-aos="fade-up">
-                <h2>Approach</h2>
-                <p>The analysis was structured in two parts: first establishing the business value of latency, then diagnosing where time was being lost.</p>
+function useWindowWidth() {
+  const [width, setWidth] = useState(typeof window !== 'undefined' ? window.innerWidth : 1200);
+  useEffect(() => {
+    const fn = () => setWidth(window.innerWidth);
+    window.addEventListener('resize', fn);
+    return () => window.removeEventListener('resize', fn);
+  }, []);
+  return width;
+}
 
-                <h3>Part 1 — Establishing the Value of Latency</h3>
-                <p>I mapped page load time against conversion rate, transaction volume, and cancellation rates across the user base. This analysis revealed a clear threshold: pages loading beyond 1 second saw conversion rates fall sharply and cancellation rates spike.</p>
-                <p><strong>1 second became the golden standard</strong> for PDP load duration — anything above it was treated as a conversion risk.</p>
-                <p>To operationalize this, I developed a new metric: <strong>TTRC % (Time To Responsive Content %)</strong> — measuring the share of page loads completing within 1 second per session. Baseline: only 40% of page loads were meeting the 1s threshold.</p>
+function hPad(w) {
+  if (w < 768) return '20px';
+  if (w < 1024) return '32px';
+  return 'max(56px, calc((100vw - 1280px) / 2))';
+}
 
-                <h3>Part 2 — Diagnosing the Remaining 60%</h3>
-                <p>I conducted a full funnel breakdown of the PDP loading sequence, decomposing total load time by individual component and analyzing each by device type, network condition, and user cohort. Key findings:</p>
-                <ul>
-                    <li><strong>Image loading:</strong> Images were loading eagerly, but 60% of users never scrolled past the first 3 images — a clear opportunity for lazy loading the rest</li>
-                    <li><strong>Async shipping/tax/coupon calculations:</strong> These were computed synchronously on page load; converting them to async based on a user's predicted conversion probability eliminated a significant blocking delay</li>
-                    <li><strong>CTA button complexity:</strong> The call-to-action button had unnecessary complexity contributing to render time; simplifying it yielded a quick win</li>
-                    <li><strong>Preloading strategies:</strong> Explored preloading key assets to reclaim time earlier in the loading sequence</li>
-                </ul>
-                <p>I proposed 4 experiments based on these findings. Two were greenlit and implemented by engineering.</p>
-            </div>
+function Nav({ dark, setDark }) {
+  const C = useC();
+  const [scrolled, setScrolled] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const w = useWindowWidth();
+  const isMobile = w < 768;
 
-            <!-- Results -->
-            <div class="project-section" data-aos="fade-up">
-                <h2>Results</h2>
-                <div class="stat-block">
-                    <div class="stat-item">
-                        <div class="stat-number">40–50%</div>
-                        <div class="stat-label">Reduction in page load time</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-number">+10%</div>
-                        <div class="stat-label">Increase in shopping conversions</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-number">$80M</div>
-                        <div class="stat-label">Incremental ARR for Meta</div>
-                    </div>
-                </div>
-                <p>Beyond the direct impact, the methodology — establishing a latency threshold first, then optimizing against it — was adopted across other pages in the shopping flow and later extended throughout the session experience.</p>
-            </div>
+  useEffect(() => {
+    const fn = () => setScrolled(window.scrollY > 50);
+    window.addEventListener('scroll', fn);
+    return () => window.removeEventListener('scroll', fn);
+  }, []);
 
-            <!-- Tech Stack -->
-            <div class="project-section" data-aos="fade-up">
-                <h2>Tech Stack</h2>
-                <div class="project-tech-row">
-                    <div class="tech-cell">
-                        <img src="../images/Sql_data_base_with_logo.png" alt="SQL">
-                    </div>
-                    <div class="tech-cell">
-                        <img src="../images/Python0logo.png" alt="Python">
-                    </div>
-                    <div class="tech-cell">
-                        <img src="../images/Tableau-Logo.png" alt="Tableau">
-                    </div>
-                </div>
-            </div>
+  const navLinks = [['Projects','../index.html#projects'],['Skills','../index.html#skills'],['Testimonials','../index.html#testimonials'],['Resume','../resume.html']];
 
-            <a href="../index.html#projects" class="back-link" data-aos="fade-up">← Back to Projects</a>
+  return (
+    <nav style={{
+      position: 'fixed', top: 0, left: 0, right: 0, zIndex: 200,
+      background: (scrolled || menuOpen) ? `${C.cream}f0` : 'transparent',
+      backdropFilter: (scrolled || menuOpen) ? 'blur(16px)' : 'none',
+      borderBottom: (scrolled || menuOpen) ? `1px solid ${C.border}` : '1px solid transparent',
+      transition: 'all 0.3s ease',
+    }}>
+      <div style={{
+        padding: isMobile ? '14px 20px' : `16px ${hPad(w)}`,
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+      }}>
+        <a href="../index.html" style={{ display: 'flex', alignItems: 'center', gap: 10, textDecoration: 'none' }}>
+          <div style={{ width: 32, height: 32, borderRadius: 6, background: ACC, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'Playfair Display', fontWeight: 900, fontSize: 16, color: '#fff' }}>R</div>
+          <span style={{ fontFamily: 'DM Sans', fontWeight: 600, fontSize: 15, color: C.ink, letterSpacing: '-0.01em' }}>Rohan Vartak</span>
+        </a>
+
+        {!isMobile && (
+          <div style={{ display: 'flex', gap: 28, alignItems: 'center' }}>
+            {navLinks.map(([l,h]) => (
+              <a key={l} href={h} style={{ fontFamily: 'DM Sans', fontSize: 13, fontWeight: 500, color: C.inkMid, textDecoration: 'none', letterSpacing: '0.01em', transition: 'color 0.2s' }}
+                onMouseEnter={e => e.target.style.color = ACC} onMouseLeave={e => e.target.style.color = C.inkMid}
+              >{l}</a>
+            ))}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+          <button onClick={() => setDark(d => !d)} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 8, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: C.inkMid, transition: 'color 0.2s, background 0.2s', outline: 'none' }}
+            onMouseEnter={e => { e.currentTarget.style.color = C.ink; e.currentTarget.style.background = C.creamCard; }}
+            onMouseLeave={e => { e.currentTarget.style.color = C.inkMid; e.currentTarget.style.background = 'none'; }}
+            title={dark ? 'Switch to light mode' : 'Switch to dark mode'}
+          >
+            {dark ? (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+              </svg>
+            ) : (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="4.5"/>
+                <line x1="12" y1="2" x2="12" y2="4.5"/>
+                <line x1="12" y1="19.5" x2="12" y2="22"/>
+                <line x1="4.22" y1="4.22" x2="5.93" y2="5.93"/>
+                <line x1="18.07" y1="18.07" x2="19.78" y2="19.78"/>
+                <line x1="2" y1="12" x2="4.5" y2="12"/>
+                <line x1="19.5" y1="12" x2="22" y2="12"/>
+                <line x1="4.22" y1="19.78" x2="5.93" y2="18.07"/>
+                <line x1="18.07" y1="5.93" x2="19.78" y2="4.22"/>
+              </svg>
+            )}
+          </button>
+          {isMobile ? (
+            <button onClick={() => setMenuOpen(o => !o)} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 8, display: 'flex', alignItems: 'center', color: C.inkMid }}>
+              {menuOpen ? (
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+              ) : (
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+              )}
+            </button>
+          ) : (
+            <a href="../index.html#contact" style={{
+              background: ACC, color: '#fff', border: 'none', borderRadius: 100,
+              padding: '9px 20px', fontSize: 13, fontWeight: 600, cursor: 'pointer',
+              fontFamily: 'DM Sans', textDecoration: 'none', transition: 'opacity 0.2s',
+            }}
+              onMouseEnter={e => e.currentTarget.style.opacity = '0.85'}
+              onMouseLeave={e => e.currentTarget.style.opacity = '1'}
+            >Get in Touch</a>
+          )}
         </div>
-    </main>
+      </div>
 
-    <footer class="footer-section">
-        <p>Designed by Rohan Vartak &copy; 2025</p>
-        <div class="footer-links">
-            <a href="https://www.linkedin.com/in/rohanvartak1996/" target="_blank"><i class="fa-brands fa-linkedin"></i></a>
-            <a href="mailto:rohanvartak1996@gmail.com"><i class="fa-solid fa-envelope"></i></a>
+      {isMobile && menuOpen && (
+        <div style={{ padding: '8px 20px 20px', borderTop: `1px solid ${C.border}`, display: 'flex', flexDirection: 'column', gap: 4 }}>
+          {navLinks.map(([l,h]) => (
+            <a key={l} href={h} onClick={() => setMenuOpen(false)} style={{ fontFamily: 'DM Sans', fontSize: 15, fontWeight: 500, color: C.inkMid, textDecoration: 'none', padding: '10px 0', borderBottom: `1px solid ${C.border}`, transition: 'color 0.2s' }}
+              onMouseEnter={e => e.target.style.color = ACC} onMouseLeave={e => e.target.style.color = C.inkMid}
+            >{l}</a>
+          ))}
+          <a href="../index.html#contact" onClick={() => setMenuOpen(false)} style={{ background: ACC, color: '#fff', borderRadius: 100, padding: '12px 24px', fontSize: 14, fontWeight: 600, textDecoration: 'none', textAlign: 'center', marginTop: 8 }}>Get in Touch</a>
         </div>
+      )}
+    </nav>
+  );
+}
+
+function Footer() {
+  const dark = React.useContext(ThemeCtx);
+  const w = useWindowWidth();
+  const isMobile = w < 640;
+  return (
+    <footer style={{ background: dark ? '#0D0B09' : '#1C1810', padding: `${isMobile ? 48 : 56}px ${hPad(w)} ${isMobile ? 24 : 32}px` }}>
+      <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : '2fr 1fr 1fr 1fr', gap: isMobile ? 32 : 40, paddingBottom: isMobile ? 32 : 48, borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+        <div style={{ gridColumn: isMobile ? '1 / -1' : 'auto' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16 }}>
+            <div style={{ width: 28, height: 28, borderRadius: 6, background: ACC, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'Playfair Display', fontWeight: 900, fontSize: 13, color: '#fff' }}>R</div>
+            <span style={{ fontFamily: 'DM Sans', fontWeight: 600, fontSize: 14, color: '#fff' }}>Rohan Vartak</span>
+          </div>
+          <p style={{ fontSize: 13, color: 'rgba(255,255,255,0.45)', lineHeight: 1.65, maxWidth: 240 }}>A data scientist on every team — building ML models that move the needle.</p>
+        </div>
+        {[
+          { label: 'Work', links: [['Projects','../index.html#projects'],['Skills','../index.html#skills'],['Resume','../resume.html']] },
+          { label: 'Social', links: [['LinkedIn','https://www.linkedin.com/in/rohanvartak1996/'],['GitHub','https://github.com/rohanvartak96']] },
+          { label: 'Contact', links: [['Get in Touch','../index.html#contact']] },
+        ].map(col => (
+          <div key={col.label}>
+            <p style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.3)', marginBottom: 16 }}>{col.label}</p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {col.links.map(([label, href]) => (
+                <a key={label} href={href} style={{ fontSize: 13, color: 'rgba(255,255,255,0.6)', textDecoration: 'none', transition: 'color 0.2s' }}
+                  onMouseEnter={e => e.target.style.color = ACC} onMouseLeave={e => e.target.style.color = 'rgba(255,255,255,0.6)'}
+                >{label}</a>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div style={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', justifyContent: 'space-between', alignItems: isMobile ? 'flex-start' : 'center', paddingTop: 24, gap: isMobile ? 8 : 0 }}>
+        <span style={{ fontSize: 12, color: 'rgba(255,255,255,0.3)' }}>Designed by Rohan Vartak © 2025</span>
+        <a href="mailto:rohanvartak1996@gmail.com" style={{ fontSize: 12, color: 'rgba(255,255,255,0.3)', textDecoration: 'none', transition: 'color 0.2s' }}
+          onMouseEnter={e => e.target.style.color = ACC} onMouseLeave={e => e.target.style.color = 'rgba(255,255,255,0.3)'}
+        >rohanvartak1996@gmail.com</a>
+      </div>
     </footer>
+  );
+}
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
-    <script>
-        AOS.init({ duration: 500, once: true, offset: 80 });
-    </script>
+function ResultCard({ prefix, value, suffix, label, sub }) {
+  const C = useC();
+  const ref = useRef(null);
+  const visible = useInView(ref);
+  const count = useCounter(value, visible);
+  return (
+    <div ref={ref} style={{ background: C.creamCard, border: `1px solid ${C.border}`, borderRadius: 14, padding: '28px 24px', textAlign: 'center' }}>
+      <div style={{ fontFamily: 'Playfair Display', fontWeight: 900, fontSize: 48, color: ACC, letterSpacing: '-0.03em', lineHeight: 1 }}>{prefix}{count}{suffix}</div>
+      <div style={{ fontSize: 14, fontWeight: 600, color: C.ink, marginTop: 10 }}>{label}</div>
+      {sub && <div style={{ fontSize: 12, color: C.inkLight, marginTop: 4 }}>{sub}</div>}
+    </div>
+  );
+}
+
+function Section({ children }) {
+  const C = useC();
+  const ref = useRef(null);
+  const visible = useInView(ref);
+  return (
+    <div ref={ref} style={{ padding: '64px 0', borderTop: `1px solid ${C.border}`, opacity: visible ? 1 : 0, transform: visible ? 'none' : 'translateY(20px)', transition: 'all 0.55s ease' }}>
+      {children}
+    </div>
+  );
+}
+
+function SectionLabel({ children }) {
+  const C = useC();
+  return <p style={{ fontFamily: 'DM Sans', fontSize: 11, fontWeight: 600, letterSpacing: '0.18em', textTransform: 'uppercase', color: C.inkLight, marginBottom: 16 }}>{children}</p>;
+}
+function SectionTitle({ children }) {
+  const C = useC();
+  return <h2 style={{ fontFamily: 'Playfair Display', fontWeight: 800, fontSize: 'clamp(26px, 3vw, 38px)', letterSpacing: '-0.02em', color: C.ink, lineHeight: 1.15, marginBottom: 24 }}>{children}</h2>;
+}
+function SubTitle({ children }) {
+  const C = useC();
+  return <h3 style={{ fontFamily: 'DM Sans', fontWeight: 700, fontSize: 17, color: C.ink, letterSpacing: '-0.01em', marginBottom: 12, marginTop: 32 }}>{children}</h3>;
+}
+function Body({ children }) {
+  const C = useC();
+  return <p style={{ fontFamily: 'DM Sans', fontSize: 15, lineHeight: 1.75, color: C.inkMid, marginBottom: 16 }}>{children}</p>;
+}
+function BulletList({ items }) {
+  const C = useC();
+  return (
+    <ul style={{ listStyle: 'none', padding: 0, display: 'flex', flexDirection: 'column', gap: 10 }}>
+      {items.map((item, i) => (
+        <li key={i} style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+          <span style={{ width: 6, height: 6, borderRadius: '50%', background: ACC, flexShrink: 0, marginTop: 8 }}></span>
+          <span style={{ fontFamily: 'DM Sans', fontSize: 15, lineHeight: 1.7, color: C.inkMid }}>{item}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function Callout({ children }) {
+  const C = useC();
+  return (
+    <div style={{ background: `${ACC}10`, border: `1px solid ${ACC}30`, borderLeft: `3px solid ${ACC}`, borderRadius: '0 10px 10px 0', padding: '16px 20px', margin: '20px 0' }}>
+      <p style={{ fontFamily: 'DM Sans', fontSize: 15, lineHeight: 1.7, color: C.inkMid }}>{children}</p>
+    </div>
+  );
+}
+
+function ProjectPage() {
+  const [dark, setDark] = useState(() => { try { return localStorage.getItem('theme') === 'dark'; } catch(e) { return false; } });
+  const T = dark ? CD : C;
+  const w = useWindowWidth();
+  const isMobile = w < 768;
+  const contentPad = isMobile ? '0 20px' : w < 1024 ? '0 32px' : '0 56px';
+
+  useEffect(() => {
+    try { localStorage.setItem('theme', dark ? 'dark' : 'light'); } catch(e) {}
+    document.documentElement.classList.toggle('dark', dark);
+  }, [dark]);
+
+  return (
+    <ThemeCtx.Provider value={dark}>
+    <div style={{ background: T.cream, minHeight: '100vh', transition: 'background 0.25s ease' }}>
+      <Nav dark={dark} setDark={setDark} />
+
+      <section style={{ padding: '120px 0 0', background: T.cream, position: 'relative', overflow: 'hidden' }}>
+        <div style={{ position: 'absolute', inset: 0, backgroundImage: `radial-gradient(circle, ${T.border} 1px, transparent 1px)`, backgroundSize: '28px 28px', pointerEvents: 'none', opacity: 0.5 }}></div>
+        <div style={{ maxWidth: 860, margin: '0 auto', padding: contentPad, position: 'relative' }}>
+          <a href="../index.html#projects" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: 'DM Sans', fontSize: 13, fontWeight: 500, color: T.inkMid, textDecoration: 'none', marginBottom: 24, transition: 'color 0.2s' }}
+            onMouseEnter={e => e.currentTarget.style.color = ACC} onMouseLeave={e => e.currentTarget.style.color = T.inkMid}
+          >← Back to Projects</a>
+          <p style={{ fontFamily: 'DM Sans', fontSize: 11, fontWeight: 500, letterSpacing: '0.18em', textTransform: 'uppercase', color: T.inkLight, marginBottom: 16 }}>Professional · Product Analytics</p>
+          <h1 style={{ fontFamily: 'Playfair Display', fontWeight: 900, fontSize: 'clamp(36px, 5vw, 68px)', letterSpacing: '-0.025em', color: T.ink, lineHeight: 1.0, marginBottom: 24 }}>
+            Instagram Shopping<br /><span style={{ fontStyle: 'italic', color: ACC }}>Latency Optimization</span>
+          </h1>
+          <p style={{ fontFamily: 'DM Sans', fontSize: isMobile ? 15 : 17, lineHeight: 1.7, color: T.inkMid, maxWidth: 620, marginBottom: 32 }}>
+            Answered a director-level question on latency ROI through deep funnel analysis — identifying and driving experiments that cut page load time by 40–50%, translating to a 10% lift in conversions and $80M ARR.
+          </p>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 56 }}>
+            {['Product Analytics','SQL','Experimentation','Funnel Analysis'].map(t => (
+              <span key={t} style={{ background: `${ACC}15`, color: ACC, border: `1px solid ${ACC}30`, borderRadius: 100, padding: '5px 14px', fontSize: 12, fontWeight: 500 }}>{t}</span>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ background: dark ? '#0D0B09' : '#1C1810', borderTop: `1px solid ${T.border}` }}>
+          <div style={{ maxWidth: 860, margin: '0 auto', padding: isMobile ? '32px 20px' : '40px 56px', display: 'grid', gridTemplateColumns: isMobile ? '1fr' : 'repeat(3, 1fr)', gap: isMobile ? 0 : 0 }}>
+            {[
+              { num: '40–50%', label: 'Reduction in page load time', sub: 'Product Description Page' },
+              { num: '+10%', label: 'Increase in conversions', sub: 'Instagram Shopping' },
+              { num: '$80M', label: 'Incremental ARR', sub: 'Meta Shopping' },
+            ].map((s, i) => (
+              <div key={i} style={{
+                padding: isMobile ? '20px 0' : '0 32px',
+                borderRight: !isMobile && i < 2 ? '1px solid rgba(255,255,255,0.08)' : 'none',
+                borderBottom: isMobile && i < 2 ? '1px solid rgba(255,255,255,0.08)' : 'none',
+              }}>
+                <div style={{ fontFamily: 'Playfair Display', fontWeight: 900, fontSize: isMobile ? 36 : 44, color: ACC, lineHeight: 1, letterSpacing: '-0.03em', marginBottom: 8 }}>{s.num}</div>
+                <div style={{ fontSize: isMobile ? 13 : 14, fontWeight: 500, color: 'rgba(255,255,255,0.85)', marginBottom: 4 }}>{s.label}</div>
+                <div style={{ fontSize: 12, color: 'rgba(255,255,255,0.4)' }}>{s.sub}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <div style={{ maxWidth: 860, margin: '0 auto', padding: contentPad }}>
+
+        <Section>
+          <SectionLabel>Overview</SectionLabel>
+          <SectionTitle>The problem</SectionTitle>
+          <Body>Instagram has a native in-app shopping flow integrated with Ads, allowing users to browse and purchase products without leaving the app. My team owned the latency of the Product Description Page (PDP) — the core page in the shopping funnel where users decide whether to convert.</Body>
+          <Body><strong>Role &amp; Scope:</strong> The Director of the Ads org asked a direct question: what is the ROI on maintaining latency? I structured and led the full analysis to answer it, then identified the highest-impact engineering improvements and drove two experiments to production.</Body>
+        </Section>
+
+        <Section>
+          <SectionLabel>Approach</SectionLabel>
+          <SectionTitle>Two-part analysis</SectionTitle>
+          <Body>The analysis was structured in two parts: first establishing the business value of latency, then diagnosing where time was being lost.</Body>
+
+          <SubTitle>Part 1 — Establishing the Value of Latency</SubTitle>
+          <Body>I mapped page load time against conversion rate, transaction volume, and cancellation rates across the user base. This analysis revealed a clear threshold: pages loading beyond 1 second saw conversion rates fall sharply and cancellation rates spike.</Body>
+          <Callout>1 second became the golden standard for PDP load duration — anything above it was treated as a conversion risk. To operationalize this, I developed a new metric: TTRC % (Time To Responsive Content %) — measuring the share of page loads completing within 1 second per session. Baseline: only 40% of page loads were meeting the 1s threshold.</Callout>
+
+          <SubTitle>Part 2 — Diagnosing the Remaining 60%</SubTitle>
+          <Body>I conducted a full funnel breakdown of the PDP loading sequence, decomposing total load time by individual component and analyzing each by device type, network condition, and user cohort. Key findings:</Body>
+          <BulletList items={[
+            "Image loading: Images were loading eagerly, but 60% of users never scrolled past the first 3 images — a clear opportunity for lazy loading the rest",
+            "Async shipping/tax/coupon calculations: These were computed synchronously on page load; converting them to async based on a user's predicted conversion probability eliminated a significant blocking delay",
+            'CTA button complexity: The call-to-action button had unnecessary complexity contributing to render time; simplifying it yielded a quick win',
+            'Preloading strategies: Explored preloading key assets to reclaim time earlier in the loading sequence',
+          ]} />
+          <Body>I proposed 4 experiments based on these findings. Two were greenlit and implemented by engineering.</Body>
+        </Section>
+
+        <Section>
+          <SectionLabel>Results</SectionLabel>
+          <SectionTitle>Measured business impact</SectionTitle>
+          <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : 'repeat(3, 1fr)', gap: 16, marginBottom: 24 }}>
+            <ResultCard prefix="" value={45} suffix="%" label="Latency reduction" sub="Page load time improvement" />
+            <ResultCard prefix="+" value={10} suffix="%" label="Conversion lift" sub="Instagram Shopping" />
+            <ResultCard prefix="$" value={80} suffix="M" label="Incremental ARR" sub="Meta Shopping" />
+          </div>
+          <Body>Beyond the direct impact, the methodology — establishing a latency threshold first, then optimizing against it — was adopted across other pages in the shopping flow and later extended throughout the session experience.</Body>
+        </Section>
+
+        <Section>
+          <SectionLabel>Tech Stack</SectionLabel>
+          <SectionTitle>Tools &amp; technologies</SectionTitle>
+          <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+            {['SQL','Python','Tableau','A/B Testing','Funnel Analysis','Statistical Modeling'].map(t => (
+              <span key={t} style={{ background: T.creamCard, border: `1px solid ${T.border}`, borderRadius: 8, padding: '10px 16px', fontSize: 13, fontWeight: 500, color: T.inkMid }}>{t}</span>
+            ))}
+          </div>
+        </Section>
+
+        <div style={{ padding: '48px 0', borderTop: `1px solid ${T.border}`, display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+          <a href="../index.html#projects" style={{ background: 'transparent', color: T.ink, border: `1.5px solid ${T.borderMid}`, borderRadius: 100, padding: '11px 24px', fontSize: 14, fontWeight: 500, fontFamily: 'DM Sans', textDecoration: 'none', transition: 'all 0.2s' }}
+            onMouseEnter={e => { e.currentTarget.style.borderColor = ACC; e.currentTarget.style.color = ACC; }}
+            onMouseLeave={e => { e.currentTarget.style.borderColor = T.borderMid; e.currentTarget.style.color = T.ink; }}
+          >← Back to Projects</a>
+          <a href="user-language-model.html" style={{ background: ACC, color: '#fff', border: 'none', borderRadius: 100, padding: '11px 24px', fontSize: 14, fontWeight: 600, fontFamily: 'DM Sans', textDecoration: 'none', transition: 'opacity 0.2s' }}
+            onMouseEnter={e => e.currentTarget.style.opacity = '0.85'} onMouseLeave={e => e.currentTarget.style.opacity = '1'}
+          >Other Project →</a>
+        </div>
+      </div>
+
+      <Footer />
+    </div>
+    </ThemeCtx.Provider>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<ProjectPage />);
+</script>
 </body>
-
 </html>

--- a/projects/projects.css
+++ b/projects/projects.css
@@ -74,7 +74,7 @@ nav {
 
 nav .left a {
     color: var(--text-color);
-    font-size: 24px;
+    font-size: 26px;
     font-weight: 600;
 }
 
@@ -90,7 +90,7 @@ nav .right {
 
 nav .right a {
     color: #666;
-    font-size: 15px;
+    font-size: 17px;
     margin-left: 8px;
     display: inline-flex;
     align-items: center;
@@ -180,7 +180,7 @@ nav .right a.nav-link--cta:hover {
         padding: 12px 16px;
         border-radius: 10px;
         margin-left: 0;
-        font-size: 16px;
+        font-size: 18px;
     }
 
     nav .right a.nav-link--cta {
@@ -196,7 +196,7 @@ nav .right a.nav-link--cta:hover {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    font-size: 14px;
+    font-size: 16px;
     font-weight: 600;
     color: var(--primary-color);
     text-decoration: none;
@@ -216,7 +216,7 @@ nav .right a.nav-link--cta:hover {
 }
 
 .project-hero h1 {
-    font-size: 42px;
+    font-size: 44px;
     font-weight: 700;
     line-height: 1.2;
     margin-bottom: 20px;
@@ -224,7 +224,7 @@ nav .right a.nav-link--cta:hover {
 }
 
 .project-hero .impact-statement {
-    font-size: 20px;
+    font-size: 22px;
     color: #555;
     margin-bottom: 24px;
     line-height: 1.6;
@@ -238,7 +238,7 @@ nav .right a.nav-link--cta:hover {
 }
 
 .project-hero .tag-row .tag {
-    font-size: 13px;
+    font-size: 15px;
     font-weight: 600;
     color: var(--primary-color);
     background-color: rgba(114, 57, 247, 0.08);
@@ -251,7 +251,7 @@ nav .right a.nav-link--cta:hover {
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    font-size: 14px;
+    font-size: 16px;
     font-weight: 600;
     color: var(--text-color);
     border: 1px solid #ddd;
@@ -277,7 +277,7 @@ nav .right a.nav-link--cta:hover {
 }
 
 .project-section h2 {
-    font-size: 26px;
+    font-size: 28px;
     font-weight: 700;
     color: var(--text-color);
     margin-bottom: 20px;
@@ -286,7 +286,7 @@ nav .right a.nav-link--cta:hover {
 }
 
 .project-section p {
-    font-size: 17px;
+    font-size: 19px;
     color: #444;
     line-height: 1.8;
     margin-bottom: 16px;
@@ -298,7 +298,7 @@ nav .right a.nav-link--cta:hover {
 }
 
 .project-section ul li {
-    font-size: 17px;
+    font-size: 19px;
     color: #444;
     line-height: 1.8;
     margin-bottom: 8px;
@@ -323,7 +323,7 @@ nav .right a.nav-link--cta:hover {
 }
 
 .stat-item .stat-number {
-    font-size: 40px;
+    font-size: 42px;
     font-weight: 700;
     color: var(--primary-color);
     line-height: 1.1;
@@ -331,7 +331,7 @@ nav .right a.nav-link--cta:hover {
 }
 
 .stat-item .stat-label {
-    font-size: 14px;
+    font-size: 16px;
     color: #666;
     font-weight: 500;
     line-height: 1.4;
@@ -382,7 +382,7 @@ nav .right a.nav-link--cta:hover {
 }
 
 .footer-section p {
-    font-size: 14px;
+    font-size: 16px;
     color: var(--muted-text);
     margin-bottom: 20px;
     font-weight: 500;
@@ -396,7 +396,7 @@ nav .right a.nav-link--cta:hover {
 
 .footer-links a {
     color: var(--text-color);
-    font-size: 22px;
+    font-size: 24px;
     transition: all 0.3s ease;
     opacity: 0.8;
 }
@@ -418,11 +418,11 @@ nav .right a.nav-link--cta:hover {
     }
 
     .project-hero h1 {
-        font-size: 30px;
+        font-size: 32px;
     }
 
     .project-hero .impact-statement {
-        font-size: 17px;
+        font-size: 19px;
     }
 
     .project-content {

--- a/projects/user-language-model.html
+++ b/projects/user-language-model.html
@@ -1,175 +1,429 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
-        integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg=="
-        crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.css" />
-
-    <title>User Language Prediction Model | Rohan Vartak</title>
-    <meta name="description" content="Built a multilabel language classifier to improve Ads targeting accuracy at Meta, driving $36M incremental ARR.">
-    <meta property="og:title" content="User Language Prediction Model | Rohan Vartak">
-    <meta property="og:description" content="Built a multilabel language classifier to improve Ads targeting accuracy at Meta, driving $36M incremental ARR.">
-    <meta property="og:image" content="https://rohanvartak96.github.io/images/Rohan2.webp">
-    <meta property="og:url" content="https://rohanvartak96.github.io/projects/user-language-model.html">
-
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🚀</text></svg>">
-    <link rel="stylesheet" href="projects.css">
-    <script src="../script.js" defer></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>User Language Prediction Model | Rohan Vartak</title>
+<meta name="description" content="How Rohan built a multilabel language classifier at Meta that drove $36M incremental ARR.">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='18' fill='%23D95F2B'/><text x='50' y='76' font-family='Playfair Display,serif' font-weight='900' font-size='68' fill='%23fff' text-anchor='middle'>R</text></svg>">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;0,800;0,900;1,700;1,800&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600;9..40,700;9..40,800&display=swap" rel="stylesheet">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<style>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
+body { background: #F4EFE6; color: #1C1810; font-family: 'DM Sans', sans-serif; -webkit-font-smoothing: antialiased; transition: background 0.25s ease, color 0.25s ease; }
+html.dark body { background: #1C1A17; color: #F0EBE1; }
+::selection { background: #D95F2B; color: #fff; }
+</style>
+<script>(function(){try{if(localStorage.getItem('theme')==='dark')document.documentElement.classList.add('dark');}catch(e){}})()</script>
 </head>
-
 <body>
-    <header class="navbar-outer">
-        <nav>
-            <div class="left">
-                <a href="../index.html">🚀 Rohan Vartak</a>
-            </div>
-            <div class="right">
-                <div class="nav-links" id="nav-links">
-                    <a href="../index.html#projects" class="nav-link">Projects</a>
-                    <a href="../index.html#testimonial-highlights" class="nav-link">Testimonials</a>
-                    <a href="../resume.html" class="nav-link">Resume</a>
-                    <a href="../index.html#contact" class="nav-link nav-link--cta">
-                        <i class="fa-solid fa-envelope"></i>
-                        <span>Contact</span>
-                    </a>
-                </div>
-                <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                </button>
-            </div>
-        </nav>
-    </header>
+<div id="root"></div>
+<script type="text/babel">
+const { useState, useEffect, useRef } = React;
 
-    <main>
-        <!-- Project Hero -->
-        <section class="project-hero">
-            <a href="../index.html#projects" class="back-link">← Back to Projects</a>
-            <h1>User Language Prediction Model</h1>
-            <p class="impact-statement">Built a multilabel language classifier to fix Ads misdelivery at Meta — correctly predicting the languages each user understands, driving $36M incremental ARR.</p>
-            <div class="tag-row">
-                <span class="tag">Gradient Boosting</span>
-                <span class="tag">Python</span>
-                <span class="tag">Ads Targeting</span>
-                <span class="tag">ML</span>
-            </div>
-        </section>
+const ACC = '#D95F2B';
+const C = {
+  cream: '#F4EFE6', creamDark: '#EDE5D8', creamCard: '#EAE3D5',
+  white: '#FFFFFF', ink: '#1C1810', inkMid: '#4A3F32', inkLight: '#8A7E70',
+  border: 'rgba(28,24,16,0.11)', borderMid: 'rgba(28,24,16,0.18)',
+};
+const CD = {
+  cream: '#1C1A17', creamDark: '#232019', creamCard: '#2B2722',
+  white: '#332E28', ink: '#F0EBE1', inkMid: '#B5A99A', inkLight: '#7A7065',
+  border: 'rgba(240,235,225,0.09)', borderMid: 'rgba(240,235,225,0.14)',
+};
+const ThemeCtx = React.createContext(false);
+function useC() { const dark = React.useContext(ThemeCtx); return dark ? CD : C; }
 
-        <!-- Project Content -->
-        <div class="project-content">
+function useInView(ref, threshold = 0.1) {
+  const [v, setV] = useState(false);
+  useEffect(() => {
+    if (!ref.current) return;
+    const obs = new IntersectionObserver(([e]) => { if (e.isIntersecting) { setV(true); obs.disconnect(); } }, { threshold });
+    obs.observe(ref.current);
+    return () => obs.disconnect();
+  }, []);
+  return v;
+}
 
-            <!-- Overview -->
-            <div class="project-section" data-aos="fade-up">
-                <h2>Overview</h2>
-                <p>Meta's Ads platform allows advertisers to target users by language. However, when ads were targeted at the language + country level, many were reaching users who didn't actually speak those languages — a misdelivery problem that hurt advertiser ROI and user experience alike.</p>
-                <p><strong>Role &amp; Scope:</strong> I was tasked with building an ML model to predict the best languages for each user — specifically, the languages they understand and are most likely to engage with in an ad context. I owned the full pipeline: ground truth design, feature engineering, model development, evaluation, and production deployment via a real-time Web API.</p>
-            </div>
+function useCounter(target, visible, duration = 1200) {
+  const [val, setVal] = useState(0);
+  useEffect(() => {
+    if (!visible) return;
+    let start = null;
+    const step = ts => {
+      if (!start) start = ts;
+      const p = Math.min((ts - start) / duration, 1);
+      setVal(Math.round((1 - Math.pow(1 - p, 3)) * target));
+      if (p < 1) requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+  }, [visible, target]);
+  return val;
+}
 
-            <!-- Approach -->
-            <div class="project-section" data-aos="fade-up">
-                <h2>Approach</h2>
-                <p>The model was a multilabel Gradient Boosted Decision Tree (GBDT) that classified languages per user and predicted the probability of understanding each language based on historical activity signals.</p>
+function useWindowWidth() {
+  const [width, setWidth] = useState(typeof window !== 'undefined' ? window.innerWidth : 1200);
+  useEffect(() => {
+    const fn = () => setWidth(window.innerWidth);
+    window.addEventListener('resize', fn);
+    return () => window.removeEventListener('resize', fn);
+  }, []);
+  return width;
+}
 
-                <h3>Ground Truth</h3>
-                <p>Ground truth was derived from user surveys, with careful experimentation across survey formats to ensure signal quality and minimize response bias.</p>
+function hPad(w) {
+  if (w < 768) return '20px';
+  if (w < 1024) return '32px';
+  return 'max(56px, calc((100vw - 1280px) / 2))';
+}
 
-                <h3>Features</h3>
-                <ul>
-                    <li><strong>Activity signals:</strong> Past impressions, likes, shares, and comment history</li>
-                    <li><strong>Geographic attributes:</strong> Country, region, locale in country</li>
-                    <li><strong>Social graph:</strong> Close friend attributes (language inference from BFFs)</li>
-                    <li><strong>Device signals:</strong> Default device locale, keyboard language</li>
-                    <li><strong>Name-based attributes</strong> for cold-start inference</li>
-                </ul>
+function Nav({ dark, setDark }) {
+  const C = useC();
+  const [scrolled, setScrolled] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const w = useWindowWidth();
+  const isMobile = w < 768;
 
-                <h3>Algorithm Choice: Gradient Boosted Decision Tree</h3>
-                <ul>
-                    <li>Handles non-linearity and complex feature interactions well — important given the mix of categorical and numerical features</li>
-                    <li>Robust to outliers and missing data, which was common in activity signals for low-engagement users</li>
-                    <li>Some user cohorts required a higher degree of learning; GBDT's boosting approach handled these uneven cohorts better than simpler models</li>
-                </ul>
-                <p>Other algorithms tested: KNN (simple user-to-user language mapping), Logistic Regression (too linear for this problem), and Random Forests (too slow at scale). GBDT offered the best balance of accuracy, precision/recall, and compute efficiency for a large, balanced dataset.</p>
+  useEffect(() => {
+    const fn = () => setScrolled(window.scrollY > 50);
+    window.addEventListener('scroll', fn);
+    return () => window.removeEventListener('scroll', fn);
+  }, []);
 
-                <h3>Key Challenges</h3>
-                <ul>
-                    <li><strong>Predicting secondary and tertiary languages:</strong> Harder to learn from activity alone — BFF graph features and geographic attributes were critical here</li>
-                    <li><strong>Cold-start users:</strong> Device locale and keyboard signals provided reliable signal for new users with sparse history</li>
-                    <li><strong>Country-level variation:</strong> Different countries have very different language distributions. Applied country-level thresholds calibrated using external data to tune precision/recall tradeoffs per market</li>
-                    <li><strong>Ground truth quality:</strong> Tested multiple survey formats before settling on one that produced clean, reliable labels</li>
-                </ul>
+  const navLinks = [['Projects','../index.html#projects'],['Skills','../index.html#skills'],['Testimonials','../index.html#testimonials'],['Resume','../resume.html']];
 
-                <h3>Deployment</h3>
-                <p>The model was deployed as a low-latency Web API built in Hack (PHP) via Meta's internal Distillery framework. On each call: permission check → feature retrieval by user ID → model inference → thresholding + fallback logic → result returned to caller + real-time log written.</p>
+  return (
+    <nav style={{
+      position: 'fixed', top: 0, left: 0, right: 0, zIndex: 200,
+      background: (scrolled || menuOpen) ? `${C.cream}f0` : 'transparent',
+      backdropFilter: (scrolled || menuOpen) ? 'blur(16px)' : 'none',
+      borderBottom: (scrolled || menuOpen) ? `1px solid ${C.border}` : '1px solid transparent',
+      transition: 'all 0.3s ease',
+    }}>
+      <div style={{
+        padding: isMobile ? '14px 20px' : `16px ${hPad(w)}`,
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+      }}>
+        <a href="../index.html" style={{ display: 'flex', alignItems: 'center', gap: 10, textDecoration: 'none' }}>
+          <div style={{ width: 32, height: 32, borderRadius: 6, background: ACC, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'Playfair Display', fontWeight: 900, fontSize: 16, color: '#fff' }}>R</div>
+          <span style={{ fontFamily: 'DM Sans', fontWeight: 600, fontSize: 15, color: C.ink, letterSpacing: '-0.01em' }}>Rohan Vartak</span>
+        </a>
 
-                <h3>Online Monitoring</h3>
-                <ul>
-                    <li><strong>Sanity checks:</strong> Average number of languages per user per country; language distribution per country</li>
-                    <li><strong>Model metrics:</strong> Precision, Recall, F1 score</li>
-                    <li><strong>Product metrics:</strong> Language Mismatch Rate, negative language feedback on posts, cross-over rates</li>
-                </ul>
-            </div>
+        {!isMobile && (
+          <div style={{ display: 'flex', gap: 28, alignItems: 'center' }}>
+            {navLinks.map(([l,h]) => (
+              <a key={l} href={h} style={{ fontFamily: 'DM Sans', fontSize: 13, fontWeight: 500, color: C.inkMid, textDecoration: 'none', letterSpacing: '0.01em', transition: 'color 0.2s' }}
+                onMouseEnter={e => e.target.style.color = ACC} onMouseLeave={e => e.target.style.color = C.inkMid}
+              >{l}</a>
+            ))}
+          </div>
+        )}
 
-            <!-- Results -->
-            <div class="project-section" data-aos="fade-up">
-                <h2>Results</h2>
-                <div class="stat-block">
-                    <div class="stat-item">
-                        <div class="stat-number">$36M</div>
-                        <div class="stat-label">Incremental ARR from improved Ads language targeting</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-number">+0.03%</div>
-                        <div class="stat-label">Incremental revenue lift in experiment</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-number">↓</div>
-                        <div class="stat-label">Language Mismatch Rate — ads now reach users in languages they actually understand</div>
-                    </div>
-                </div>
-                <p>The experiment demonstrated that showing ads matching a user's actual language preferences drove measurable incremental revenue, validating the approach and leading to a full production rollout.</p>
-            </div>
-
-            <!-- Tech Stack -->
-            <div class="project-section" data-aos="fade-up">
-                <h2>Tech Stack</h2>
-                <div class="project-tech-row">
-                    <div class="tech-cell">
-                        <img src="../images/xgboost.png" alt="XGBoost / GBDT">
-                    </div>
-                    <div class="tech-cell">
-                        <img src="../images/Python0logo.png" alt="Python">
-                    </div>
-                    <div class="tech-cell">
-                        <img src="../images/Sql_data_base_with_logo.png" alt="SQL">
-                    </div>
-                </div>
-            </div>
-
-            <a href="../index.html#projects" class="back-link" data-aos="fade-up">← Back to Projects</a>
+        <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+          <button onClick={() => setDark(d => !d)} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 8, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: C.inkMid, transition: 'color 0.2s, background 0.2s', outline: 'none' }}
+            onMouseEnter={e => { e.currentTarget.style.color = C.ink; e.currentTarget.style.background = C.creamCard; }}
+            onMouseLeave={e => { e.currentTarget.style.color = C.inkMid; e.currentTarget.style.background = 'none'; }}
+            title={dark ? 'Switch to light mode' : 'Switch to dark mode'}
+          >
+            {dark ? (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+              </svg>
+            ) : (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="4.5"/>
+                <line x1="12" y1="2" x2="12" y2="4.5"/>
+                <line x1="12" y1="19.5" x2="12" y2="22"/>
+                <line x1="4.22" y1="4.22" x2="5.93" y2="5.93"/>
+                <line x1="18.07" y1="18.07" x2="19.78" y2="19.78"/>
+                <line x1="2" y1="12" x2="4.5" y2="12"/>
+                <line x1="19.5" y1="12" x2="22" y2="12"/>
+                <line x1="4.22" y1="19.78" x2="5.93" y2="18.07"/>
+                <line x1="18.07" y1="5.93" x2="19.78" y2="4.22"/>
+              </svg>
+            )}
+          </button>
+          {isMobile ? (
+            <button onClick={() => setMenuOpen(o => !o)} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 8, display: 'flex', alignItems: 'center', color: C.inkMid }}>
+              {menuOpen ? (
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+              ) : (
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+              )}
+            </button>
+          ) : (
+            <a href="../index.html#contact" style={{
+              background: ACC, color: '#fff', border: 'none', borderRadius: 100,
+              padding: '9px 20px', fontSize: 13, fontWeight: 600, cursor: 'pointer',
+              fontFamily: 'DM Sans', textDecoration: 'none', transition: 'opacity 0.2s',
+            }}
+              onMouseEnter={e => e.currentTarget.style.opacity = '0.85'}
+              onMouseLeave={e => e.currentTarget.style.opacity = '1'}
+            >Get in Touch</a>
+          )}
         </div>
-    </main>
+      </div>
 
-    <footer class="footer-section">
-        <p>Designed by Rohan Vartak &copy; 2025</p>
-        <div class="footer-links">
-            <a href="https://www.linkedin.com/in/rohanvartak1996/" target="_blank"><i class="fa-brands fa-linkedin"></i></a>
-            <a href="mailto:rohanvartak1996@gmail.com"><i class="fa-solid fa-envelope"></i></a>
+      {isMobile && menuOpen && (
+        <div style={{ padding: '8px 20px 20px', borderTop: `1px solid ${C.border}`, display: 'flex', flexDirection: 'column', gap: 4 }}>
+          {navLinks.map(([l,h]) => (
+            <a key={l} href={h} onClick={() => setMenuOpen(false)} style={{ fontFamily: 'DM Sans', fontSize: 15, fontWeight: 500, color: C.inkMid, textDecoration: 'none', padding: '10px 0', borderBottom: `1px solid ${C.border}`, transition: 'color 0.2s' }}
+              onMouseEnter={e => e.target.style.color = ACC} onMouseLeave={e => e.target.style.color = C.inkMid}
+            >{l}</a>
+          ))}
+          <a href="../index.html#contact" onClick={() => setMenuOpen(false)} style={{ background: ACC, color: '#fff', borderRadius: 100, padding: '12px 24px', fontSize: 14, fontWeight: 600, textDecoration: 'none', textAlign: 'center', marginTop: 8 }}>Get in Touch</a>
         </div>
+      )}
+    </nav>
+  );
+}
+
+function Footer() {
+  const dark = React.useContext(ThemeCtx);
+  const w = useWindowWidth();
+  const isMobile = w < 640;
+  return (
+    <footer style={{ background: dark ? '#0D0B09' : '#1C1810', padding: `${isMobile ? 48 : 56}px ${hPad(w)} ${isMobile ? 24 : 32}px` }}>
+      <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : '2fr 1fr 1fr 1fr', gap: isMobile ? 32 : 40, paddingBottom: isMobile ? 32 : 48, borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+        <div style={{ gridColumn: isMobile ? '1 / -1' : 'auto' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16 }}>
+            <div style={{ width: 28, height: 28, borderRadius: 6, background: ACC, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'Playfair Display', fontWeight: 900, fontSize: 13, color: '#fff' }}>R</div>
+            <span style={{ fontFamily: 'DM Sans', fontWeight: 600, fontSize: 14, color: '#fff' }}>Rohan Vartak</span>
+          </div>
+          <p style={{ fontSize: 13, color: 'rgba(255,255,255,0.45)', lineHeight: 1.65, maxWidth: 240 }}>A data scientist on every team — building ML models that move the needle.</p>
+        </div>
+        {[
+          { label: 'Work', links: [['Projects','../index.html#projects'],['Skills','../index.html#skills'],['Resume','../resume.html']] },
+          { label: 'Social', links: [['LinkedIn','https://www.linkedin.com/in/rohanvartak1996/'],['GitHub','https://github.com/rohanvartak96']] },
+          { label: 'Contact', links: [['Get in Touch','../index.html#contact']] },
+        ].map(col => (
+          <div key={col.label}>
+            <p style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.3)', marginBottom: 16 }}>{col.label}</p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {col.links.map(([label, href]) => (
+                <a key={label} href={href} style={{ fontSize: 13, color: 'rgba(255,255,255,0.6)', textDecoration: 'none', transition: 'color 0.2s' }}
+                  onMouseEnter={e => e.target.style.color = ACC} onMouseLeave={e => e.target.style.color = 'rgba(255,255,255,0.6)'}
+                >{label}</a>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div style={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', justifyContent: 'space-between', alignItems: isMobile ? 'flex-start' : 'center', paddingTop: 24, gap: isMobile ? 8 : 0 }}>
+        <span style={{ fontSize: 12, color: 'rgba(255,255,255,0.3)' }}>Designed by Rohan Vartak © 2025</span>
+        <a href="mailto:rohanvartak1996@gmail.com" style={{ fontSize: 12, color: 'rgba(255,255,255,0.3)', textDecoration: 'none', transition: 'color 0.2s' }}
+          onMouseEnter={e => e.target.style.color = ACC} onMouseLeave={e => e.target.style.color = 'rgba(255,255,255,0.3)'}
+        >rohanvartak1996@gmail.com</a>
+      </div>
     </footer>
+  );
+}
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
-    <script>
-        AOS.init({ duration: 500, once: true, offset: 80 });
-    </script>
+function ResultCard({ prefix, value, suffix, label, sub }) {
+  const C = useC();
+  const ref = useRef(null);
+  const visible = useInView(ref);
+  const count = useCounter(value, visible);
+  return (
+    <div ref={ref} style={{ background: C.creamCard, border: `1px solid ${C.border}`, borderRadius: 14, padding: '28px 24px', textAlign: 'center' }}>
+      <div style={{ fontFamily: 'Playfair Display', fontWeight: 900, fontSize: 48, color: ACC, letterSpacing: '-0.03em', lineHeight: 1 }}>{prefix}{count}{suffix}</div>
+      <div style={{ fontSize: 14, fontWeight: 600, color: C.ink, marginTop: 10 }}>{label}</div>
+      {sub && <div style={{ fontSize: 12, color: C.inkLight, marginTop: 4 }}>{sub}</div>}
+    </div>
+  );
+}
+
+function Section({ children }) {
+  const C = useC();
+  const ref = useRef(null);
+  const visible = useInView(ref);
+  return (
+    <div ref={ref} style={{ padding: '64px 0', borderTop: `1px solid ${C.border}`, opacity: visible ? 1 : 0, transform: visible ? 'none' : 'translateY(20px)', transition: 'all 0.55s ease' }}>
+      {children}
+    </div>
+  );
+}
+
+function SectionLabel({ children }) {
+  const C = useC();
+  return <p style={{ fontFamily: 'DM Sans', fontSize: 11, fontWeight: 600, letterSpacing: '0.18em', textTransform: 'uppercase', color: C.inkLight, marginBottom: 16 }}>{children}</p>;
+}
+function SectionTitle({ children }) {
+  const C = useC();
+  return <h2 style={{ fontFamily: 'Playfair Display', fontWeight: 800, fontSize: 'clamp(26px, 3vw, 38px)', letterSpacing: '-0.02em', color: C.ink, lineHeight: 1.15, marginBottom: 24 }}>{children}</h2>;
+}
+function SubTitle({ children }) {
+  const C = useC();
+  return <h3 style={{ fontFamily: 'DM Sans', fontWeight: 700, fontSize: 17, color: C.ink, letterSpacing: '-0.01em', marginBottom: 12, marginTop: 32 }}>{children}</h3>;
+}
+function Body({ children }) {
+  const C = useC();
+  return <p style={{ fontFamily: 'DM Sans', fontSize: 15, lineHeight: 1.75, color: C.inkMid, marginBottom: 16 }}>{children}</p>;
+}
+function BulletList({ items }) {
+  const C = useC();
+  return (
+    <ul style={{ listStyle: 'none', padding: 0, display: 'flex', flexDirection: 'column', gap: 10 }}>
+      {items.map((item, i) => (
+        <li key={i} style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+          <span style={{ width: 6, height: 6, borderRadius: '50%', background: ACC, flexShrink: 0, marginTop: 8 }}></span>
+          <span style={{ fontFamily: 'DM Sans', fontSize: 15, lineHeight: 1.7, color: C.inkMid }}>{item}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ProjectPage() {
+  const [dark, setDark] = useState(() => { try { return localStorage.getItem('theme') === 'dark'; } catch(e) { return false; } });
+  const T = dark ? CD : C;
+  const w = useWindowWidth();
+  const isMobile = w < 768;
+  const contentPad = isMobile ? '0 20px' : w < 1024 ? '0 32px' : '0 56px';
+
+  useEffect(() => {
+    try { localStorage.setItem('theme', dark ? 'dark' : 'light'); } catch(e) {}
+    document.documentElement.classList.toggle('dark', dark);
+  }, [dark]);
+
+  return (
+    <ThemeCtx.Provider value={dark}>
+    <div style={{ background: T.cream, minHeight: '100vh', transition: 'background 0.25s ease' }}>
+      <Nav dark={dark} setDark={setDark} />
+
+      <section style={{ padding: '120px 0 0', background: T.cream, position: 'relative', overflow: 'hidden' }}>
+        <div style={{ position: 'absolute', inset: 0, backgroundImage: `radial-gradient(circle, ${T.border} 1px, transparent 1px)`, backgroundSize: '28px 28px', pointerEvents: 'none', opacity: 0.5 }}></div>
+        <div style={{ maxWidth: 860, margin: '0 auto', padding: contentPad, position: 'relative' }}>
+          <a href="../index.html#projects" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: 'DM Sans', fontSize: 13, fontWeight: 500, color: T.inkMid, textDecoration: 'none', marginBottom: 24, transition: 'color 0.2s' }}
+            onMouseEnter={e => e.currentTarget.style.color = ACC} onMouseLeave={e => e.currentTarget.style.color = T.inkMid}
+          >← Back to Projects</a>
+          <p style={{ fontFamily: 'DM Sans', fontSize: 11, fontWeight: 500, letterSpacing: '0.18em', textTransform: 'uppercase', color: T.inkLight, marginBottom: 16 }}>Professional · ML Engineering</p>
+          <h1 style={{ fontFamily: 'Playfair Display', fontWeight: 900, fontSize: 'clamp(36px, 5vw, 68px)', letterSpacing: '-0.025em', color: T.ink, lineHeight: 1.0, marginBottom: 24 }}>
+            User Language<br /><span style={{ fontStyle: 'italic', color: ACC }}>Prediction Model</span>
+          </h1>
+          <p style={{ fontFamily: 'DM Sans', fontSize: isMobile ? 15 : 17, lineHeight: 1.7, color: T.inkMid, maxWidth: 620, marginBottom: 32 }}>
+            Built a multilabel language classifier to fix Ads misdelivery at Meta — correctly predicting the languages each user understands, driving $36M incremental ARR.
+          </p>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 56 }}>
+            {['Gradient Boosting','Python','Ads Targeting','ML'].map(t => (
+              <span key={t} style={{ background: `${ACC}15`, color: ACC, border: `1px solid ${ACC}30`, borderRadius: 100, padding: '5px 14px', fontSize: 12, fontWeight: 500 }}>{t}</span>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ background: dark ? '#0D0B09' : '#1C1810', borderTop: `1px solid ${T.border}` }}>
+          <div style={{ maxWidth: 860, margin: '0 auto', padding: isMobile ? '32px 20px' : '40px 56px', display: 'grid', gridTemplateColumns: isMobile ? '1fr' : 'repeat(3, 1fr)' }}>
+            {[
+              { num: '$36M', label: 'Incremental ARR', sub: 'From improved language targeting' },
+              { num: '+0.03%', label: 'Revenue lift in experiment', sub: 'Statistically significant' },
+              { num: '↓', label: 'Language Mismatch Rate', sub: 'Ads in languages users understand' },
+            ].map((s, i) => (
+              <div key={i} style={{
+                padding: isMobile ? '20px 0' : '0 32px',
+                borderRight: !isMobile && i < 2 ? '1px solid rgba(255,255,255,0.08)' : 'none',
+                borderBottom: isMobile && i < 2 ? '1px solid rgba(255,255,255,0.08)' : 'none',
+              }}>
+                <div style={{ fontFamily: 'Playfair Display', fontWeight: 900, fontSize: isMobile ? 36 : 44, color: ACC, lineHeight: 1, letterSpacing: '-0.03em', marginBottom: 8 }}>{s.num}</div>
+                <div style={{ fontSize: isMobile ? 13 : 14, fontWeight: 500, color: 'rgba(255,255,255,0.85)', marginBottom: 4 }}>{s.label}</div>
+                <div style={{ fontSize: 12, color: 'rgba(255,255,255,0.4)' }}>{s.sub}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <div style={{ maxWidth: 860, margin: '0 auto', padding: contentPad }}>
+
+        <Section>
+          <SectionLabel>Overview</SectionLabel>
+          <SectionTitle>The problem</SectionTitle>
+          <Body>Meta's Ads platform allows advertisers to target users by language. However, when ads were targeted at the language + country level, many were reaching users who didn't actually speak those languages — a misdelivery problem that hurt advertiser ROI and user experience alike.</Body>
+          <Body><strong>Role &amp; Scope:</strong> I was tasked with building an ML model to predict the best languages for each user — specifically, the languages they understand and are most likely to engage with in an ad context. I owned the full pipeline: ground truth design, feature engineering, model development, evaluation, and production deployment via a real-time Web API.</Body>
+        </Section>
+
+        <Section>
+          <SectionLabel>Approach</SectionLabel>
+          <SectionTitle>How I built it</SectionTitle>
+          <Body>The model was a multilabel Gradient Boosted Decision Tree (GBDT) that classified languages per user and predicted the probability of understanding each language based on historical activity signals.</Body>
+
+          <SubTitle>Ground Truth</SubTitle>
+          <Body>Ground truth was derived from user surveys, with careful experimentation across survey formats to ensure signal quality and minimize response bias.</Body>
+
+          <SubTitle>Features</SubTitle>
+          <BulletList items={[
+            'Activity signals: Past impressions, likes, shares, and comment history',
+            'Geographic attributes: Country, region, locale in country',
+            'Social graph: Close friend attributes (language inference from BFFs)',
+            'Device signals: Default device locale, keyboard language',
+            'Name-based attributes for cold-start inference',
+          ]} />
+
+          <SubTitle>Algorithm Choice: Gradient Boosted Decision Tree</SubTitle>
+          <BulletList items={[
+            'Handles non-linearity and complex feature interactions well — important given the mix of categorical and numerical features',
+            "Robust to outliers and missing data, which was common in activity signals for low-engagement users",
+            "Some user cohorts required a higher degree of learning; GBDT's boosting approach handled these uneven cohorts better than simpler models",
+          ]} />
+          <Body>Other algorithms tested: KNN (simple user-to-user language mapping), Logistic Regression (too linear for this problem), and Random Forests (too slow at scale). GBDT offered the best balance of accuracy, precision/recall, and compute efficiency.</Body>
+
+          <SubTitle>Key Challenges</SubTitle>
+          <BulletList items={[
+            'Predicting secondary and tertiary languages: Harder to learn from activity alone — BFF graph features and geographic attributes were critical here',
+            'Cold-start users: Device locale and keyboard signals provided reliable signal for new users with sparse history',
+            "Country-level variation: Applied country-level thresholds calibrated using external data to tune precision/recall tradeoffs per market",
+            'Ground truth quality: Tested multiple survey formats before settling on one that produced clean, reliable labels',
+          ]} />
+
+          <SubTitle>Deployment</SubTitle>
+          <Body>The model was deployed as a low-latency Web API built in Hack (PHP) via Meta's internal Distillery framework. On each call: permission check → feature retrieval by user ID → model inference → thresholding + fallback logic → result returned to caller + real-time log written.</Body>
+          <Body><strong>Online Monitoring:</strong> Sanity checks on language distribution per country; model metrics (Precision, Recall, F1); product metrics (Language Mismatch Rate, negative language feedback on posts, cross-over rates).</Body>
+        </Section>
+
+        <Section>
+          <SectionLabel>Results</SectionLabel>
+          <SectionTitle>Measured business impact</SectionTitle>
+          <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : 'repeat(3, 1fr)', gap: 16, marginBottom: 24 }}>
+            <ResultCard prefix="$" value={36} suffix="M" label="Incremental ARR" sub="Meta Ads language targeting" />
+            <ResultCard prefix="+" value={0} suffix=".03%" label="Revenue lift" sub="Statistically significant" />
+            <ResultCard prefix="" value={95} suffix="%" label="Model recall" sub="High-recall production model" />
+          </div>
+          <Body>The experiment demonstrated that showing ads matching a user's actual language preferences drove measurable incremental revenue, validating the approach and leading to a full production rollout.</Body>
+        </Section>
+
+        <Section>
+          <SectionLabel>Tech Stack</SectionLabel>
+          <SectionTitle>Tools &amp; technologies</SectionTitle>
+          <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+            {['Gradient Boosting / XGBoost','Python','SQL','Hack (PHP)','Meta Distillery','A/B Testing'].map(t => (
+              <span key={t} style={{ background: T.creamCard, border: `1px solid ${T.border}`, borderRadius: 8, padding: '10px 16px', fontSize: 13, fontWeight: 500, color: T.inkMid }}>{t}</span>
+            ))}
+          </div>
+        </Section>
+
+        <div style={{ padding: '48px 0', borderTop: `1px solid ${T.border}`, display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+          <a href="../index.html#projects" style={{ background: 'transparent', color: T.ink, border: `1.5px solid ${T.borderMid}`, borderRadius: 100, padding: '11px 24px', fontSize: 14, fontWeight: 500, fontFamily: 'DM Sans', textDecoration: 'none', transition: 'all 0.2s' }}
+            onMouseEnter={e => { e.currentTarget.style.borderColor = ACC; e.currentTarget.style.color = ACC; }}
+            onMouseLeave={e => { e.currentTarget.style.borderColor = T.borderMid; e.currentTarget.style.color = T.ink; }}
+          >← Back to Projects</a>
+          <a href="instagram-latency.html" style={{ background: ACC, color: '#fff', border: 'none', borderRadius: 100, padding: '11px 24px', fontSize: 14, fontWeight: 600, fontFamily: 'DM Sans', textDecoration: 'none', transition: 'opacity 0.2s' }}
+            onMouseEnter={e => e.currentTarget.style.opacity = '0.85'} onMouseLeave={e => e.currentTarget.style.opacity = '1'}
+          >Next Project →</a>
+        </div>
+      </div>
+
+      <Footer />
+    </div>
+    </ThemeCtx.Provider>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<ProjectPage />);
+</script>
 </body>
-
 </html>

--- a/resume.html
+++ b/resume.html
@@ -1,372 +1,271 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
-        integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg=="
-        crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🚀</text></svg>">
-    <title>Resume | Rohan Vartak</title>
-    <script src="script.js" defer></script>
-    <style>
-        :root {
-            --primary-color: #7239f7;
-            --text-color: #1a1c20;
-            --background-color: #ffffff;
-            --nav-bg: rgba(255, 255, 255, 0.95);
-            --border-color: #e8e8e8;
-            --muted: #888;
-            --font-family: 'Geist', sans-serif;
-        }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
-        html { scroll-behavior: smooth; scroll-padding-top: 80px; }
-
-        body {
-            font-family: var(--font-family);
-            background: #f7f7f8;
-            color: var(--text-color);
-            min-height: 100vh;
-        }
-
-        /* Navbar — matches main site */
-        .navbar-outer {
-            position: fixed;
-            top: 0;
-            left: 0;
-            right: 0;
-            width: 100%;
-            z-index: 1000;
-            background-color: transparent;
-            backdrop-filter: none;
-            box-shadow: none;
-            transition: background-color 0.3s ease, backdrop-filter 0.3s ease, box-shadow 0.3s ease;
-        }
-
-        .navbar-outer.scrolled {
-            background-color: var(--nav-bg);
-            backdrop-filter: blur(10px);
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
-        }
-
-        nav {
-            display: flex;
-            justify-content: space-between;
-            padding: 0 50px;
-            height: 70px;
-            align-items: center;
-            max-width: 1400px;
-            margin: 0 auto;
-        }
-
-        nav .left a {
-            color: var(--text-color);
-            font-size: 24px;
-            font-weight: 600;
-            text-decoration: none;
-        }
-
-        nav .right {
-            display: flex;
-            align-items: center;
-        }
-
-        .nav-links {
-            display: flex;
-            align-items: center;
-        }
-
-        nav .right a {
-            color: #666;
-            font-size: 15px;
-            margin-left: 8px;
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-            font-weight: 500;
-            padding: 6px 14px;
-            border-radius: 8px;
-            text-decoration: none;
-            transition: color 0.2s ease, background 0.2s ease;
-        }
-
-        nav .right a:hover {
-            color: var(--text-color);
-            background: rgba(0, 0, 0, 0.04);
-        }
-
-        nav .right a.nav-link--active {
-            color: var(--primary-color);
-            background: rgba(114, 57, 247, 0.07);
-            font-weight: 600;
-        }
-
-        nav .right a.nav-link--cta {
-            color: #fff;
-            background-color: var(--text-color);
-            padding: 8px 20px;
-            border-radius: 50px;
-            margin-left: 12px;
-            transition: background-color 0.2s ease;
-        }
-
-        nav .right a.nav-link--cta:hover {
-            background-color: var(--primary-color);
-            color: #fff;
-        }
-
-        .nav-hamburger {
-            display: none;
-            flex-direction: column;
-            justify-content: center;
-            gap: 5px;
-            background: none;
-            border: none;
-            cursor: pointer;
-            padding: 6px 4px;
-            margin-left: 8px;
-        }
-
-        .nav-hamburger span {
-            display: block;
-            width: 22px;
-            height: 2px;
-            background: var(--text-color);
-            border-radius: 2px;
-            transition: transform 0.3s ease, opacity 0.2s ease;
-        }
-
-        .nav-hamburger.open span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
-        .nav-hamburger.open span:nth-child(2) { opacity: 0; transform: scaleX(0); }
-        .nav-hamburger.open span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
-
-        @media (max-width: 768px) {
-            nav { padding: 0 20px; }
-            .nav-hamburger { display: flex; }
-
-            .nav-links {
-                display: none;
-                position: absolute;
-                top: 70px;
-                left: 0;
-                right: 0;
-                flex-direction: column;
-                align-items: stretch;
-                background: rgba(255, 255, 255, 0.97);
-                backdrop-filter: blur(14px);
-                padding: 12px 20px 20px;
-                gap: 4px;
-                box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
-                border-bottom: 1px solid var(--border-color);
-            }
-
-            .nav-links.open { display: flex; }
-
-            nav .right a.nav-link {
-                padding: 12px 16px;
-                border-radius: 10px;
-                margin-left: 0;
-                font-size: 16px;
-            }
-
-            nav .right a.nav-link--cta {
-                margin-left: 0;
-                margin-top: 8px;
-                justify-content: center;
-                padding: 12px 20px;
-            }
-        }
-
-        /* Page content */
-        .page {
-            max-width: 860px;
-            margin: 0 auto;
-            padding: 100px 24px 80px;
-        }
-
-        .resume-header {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            margin-bottom: 28px;
-        }
-
-        .resume-header h1 {
-            font-size: 28px;
-            font-weight: 600;
-            color: var(--text-color);
-            letter-spacing: -0.3px;
-        }
-
-        .download-btn {
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-            background: var(--primary-color);
-            color: #fff;
-            text-decoration: none;
-            padding: 9px 20px;
-            border-radius: 8px;
-            font-size: 14px;
-            font-weight: 600;
-            transition: all 0.2s ease;
-        }
-
-        .download-btn:hover {
-            background: #5f2de0;
-            transform: translateY(-1px);
-            box-shadow: 0 4px 14px rgba(114, 57, 247, 0.35);
-            color: #fff;
-        }
-
-        .resume-frame-wrapper {
-            background: #fff;
-            border: 1px solid var(--border-color);
-            border-radius: 10px;
-            overflow: hidden;
-            box-shadow: 0 4px 24px rgba(0,0,0,0.07);
-        }
-
-        .resume-frame-wrapper iframe {
-            display: block;
-            width: 100%;
-            aspect-ratio: 8.5 / 11;
-            min-height: 640px;
-            border: none;
-        }
-
-        .resume-note {
-            margin-top: 14px;
-            font-size: 13px;
-            color: var(--muted);
-            text-align: center;
-        }
-
-        .resume-note a {
-            color: var(--primary-color);
-            text-decoration: none;
-            font-weight: 500;
-        }
-
-        .resume-note a:hover { text-decoration: underline; }
-
-        /* Back link */
-        .back-link {
-            display: inline-flex;
-            align-items: center;
-            gap: 6px;
-            font-size: 14px;
-            font-weight: 600;
-            color: var(--primary-color);
-            text-decoration: none;
-            margin-bottom: 28px;
-            transition: gap 0.2s ease;
-        }
-
-        .back-link:hover { gap: 10px; color: var(--primary-color); }
-
-        /* Footer */
-        .footer-section {
-            text-align: center;
-            padding: 48px 20px;
-            border-top: 1px solid var(--border-color);
-            margin-top: 60px;
-        }
-
-        .footer-section p {
-            font-size: 14px;
-            color: var(--muted);
-            margin-bottom: 16px;
-            font-weight: 500;
-        }
-
-        .footer-links {
-            display: flex;
-            justify-content: center;
-            gap: 24px;
-        }
-
-        .footer-links a {
-            color: var(--text-color);
-            font-size: 22px;
-            opacity: 0.8;
-            text-decoration: none;
-            transition: color 0.2s ease, transform 0.2s ease, opacity 0.2s ease;
-        }
-
-        .footer-links a:hover {
-            color: var(--primary-color);
-            transform: translateY(-3px);
-            opacity: 1;
-        }
-
-        @media (max-width: 600px) {
-            .resume-header { flex-direction: column; align-items: flex-start; gap: 16px; }
-            .resume-header h1 { font-size: 22px; }
-            .page { padding: 90px 16px 60px; }
-        }
-    </style>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Resume | Rohan Vartak</title>
+<meta name="description" content="Rohan Vartak's resume — Data Scientist & ML Engineer at Meta.">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='18' fill='%23D95F2B'/><text x='50' y='76' font-family='Playfair Display,serif' font-weight='900' font-size='68' fill='%23fff' text-anchor='middle'>R</text></svg>">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;0,800;0,900;1,700;1,800&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600;9..40,700;9..40,800&display=swap" rel="stylesheet">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<style>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
+body { background: #F4EFE6; color: #1C1810; font-family: 'DM Sans', sans-serif; -webkit-font-smoothing: antialiased; min-height: 100vh; transition: background 0.25s ease, color 0.25s ease; }
+html.dark body { background: #1C1A17; color: #F0EBE1; }
+::selection { background: #D95F2B; color: #fff; }
+</style>
+<script>(function(){try{if(localStorage.getItem('theme')==='dark')document.documentElement.classList.add('dark');}catch(e){}})()</script>
 </head>
-
 <body>
-    <header class="navbar-outer">
-        <nav>
-            <div class="left">
-                <a href="index.html">🚀 Rohan Vartak</a>
-            </div>
-            <div class="right">
-                <div class="nav-links" id="nav-links">
-                    <a href="index.html#projects" class="nav-link">Projects</a>
-                    <a href="index.html#testimonial-highlights" class="nav-link">Testimonials</a>
-                    <a href="resume.html" class="nav-link nav-link--active">Resume</a>
-                    <a href="index.html#contact" class="nav-link nav-link--cta">
-                        <i class="fa-solid fa-envelope"></i>
-                        <span>Contact</span>
-                    </a>
-                </div>
-                <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                </button>
-            </div>
-        </nav>
-    </header>
+<div id="root"></div>
+<script type="text/babel">
+const { useState, useEffect } = React;
 
-    <div class="page">
-        <a href="index.html" class="back-link">
-            <i class="fa-solid fa-arrow-left"></i> Back to Portfolio
+const ACC = '#D95F2B';
+const C = {
+  cream: '#F4EFE6', creamDark: '#EDE5D8', creamCard: '#EAE3D5',
+  white: '#FFFFFF', ink: '#1C1810', inkMid: '#4A3F32', inkLight: '#8A7E70',
+  border: 'rgba(28,24,16,0.11)', borderMid: 'rgba(28,24,16,0.18)',
+};
+const CD = {
+  cream: '#1C1A17', creamDark: '#232019', creamCard: '#2B2722',
+  white: '#332E28', ink: '#F0EBE1', inkMid: '#B5A99A', inkLight: '#7A7065',
+  border: 'rgba(240,235,225,0.09)', borderMid: 'rgba(240,235,225,0.14)',
+};
+const ThemeCtx = React.createContext(false);
+function useC() { const dark = React.useContext(ThemeCtx); return dark ? CD : C; }
+
+function useWindowWidth() {
+  const [width, setWidth] = useState(typeof window !== 'undefined' ? window.innerWidth : 1200);
+  useEffect(() => {
+    const fn = () => setWidth(window.innerWidth);
+    window.addEventListener('resize', fn);
+    return () => window.removeEventListener('resize', fn);
+  }, []);
+  return width;
+}
+
+function hPad(w) {
+  if (w < 768) return '20px';
+  if (w < 1024) return '32px';
+  return 'max(56px, calc((100vw - 1280px) / 2))';
+}
+
+function Nav({ dark, setDark }) {
+  const C = useC();
+  const [scrolled, setScrolled] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const w = useWindowWidth();
+  const isMobile = w < 768;
+
+  useEffect(() => {
+    const fn = () => setScrolled(window.scrollY > 50);
+    window.addEventListener('scroll', fn);
+    return () => window.removeEventListener('scroll', fn);
+  }, []);
+
+  const navLinks = [['Projects','index.html#projects'],['Skills','index.html#skills'],['Testimonials','index.html#testimonials'],['Resume','resume.html']];
+
+  return (
+    <nav style={{
+      position: 'fixed', top: 0, left: 0, right: 0, zIndex: 200,
+      background: (scrolled || menuOpen) ? `${C.cream}f0` : 'transparent',
+      backdropFilter: (scrolled || menuOpen) ? 'blur(16px)' : 'none',
+      borderBottom: (scrolled || menuOpen) ? `1px solid ${C.border}` : '1px solid transparent',
+      transition: 'all 0.3s ease',
+    }}>
+      <div style={{
+        padding: isMobile ? '14px 20px' : `16px ${hPad(w)}`,
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+      }}>
+        <a href="index.html" style={{ display: 'flex', alignItems: 'center', gap: 10, textDecoration: 'none' }}>
+          <div style={{ width: 32, height: 32, borderRadius: 6, background: ACC, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'Playfair Display', fontWeight: 900, fontSize: 16, color: '#fff' }}>R</div>
+          <span style={{ fontFamily: 'DM Sans', fontWeight: 600, fontSize: 15, color: C.ink, letterSpacing: '-0.01em' }}>Rohan Vartak</span>
         </a>
-        <div class="resume-header">
-            <h1>Resume</h1>
-            <a href="Rohan Vartak Resume.pdf" download class="download-btn">
-                <i class="fa-solid fa-download"></i>
-                Download PDF
-            </a>
-        </div>
 
-        <div class="resume-frame-wrapper">
-            <iframe src="Rohan Vartak Resume.pdf" title="Rohan Vartak Resume"></iframe>
-        </div>
+        {!isMobile && (
+          <div style={{ display: 'flex', gap: 28, alignItems: 'center' }}>
+            {navLinks.map(([l,h]) => (
+              <a key={l} href={h} style={{ fontFamily: 'DM Sans', fontSize: 13, fontWeight: 500, color: C.inkMid, textDecoration: 'none', letterSpacing: '0.01em', transition: 'color 0.2s' }}
+                onMouseEnter={e => e.target.style.color = ACC}
+                onMouseLeave={e => e.target.style.color = C.inkMid}
+              >{l}</a>
+            ))}
+          </div>
+        )}
 
-        <p class="resume-note">
-            Download the <a href="Rohan Vartak Resume.pdf" download>PDF</a> for clickable links.
-        </p>
-    </div>
-
-    <footer class="footer-section">
-        <p>Designed by Rohan Vartak &copy; 2025</p>
-        <div class="footer-links">
-            <a href="https://www.linkedin.com/in/rohanvartak1996/" target="_blank"><i class="fa-brands fa-linkedin"></i></a>
-            <a href="mailto:rohanvartak1996@gmail.com"><i class="fa-solid fa-envelope"></i></a>
+        <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+          <button onClick={() => setDark(d => !d)} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 8, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: C.inkMid, transition: 'color 0.2s, background 0.2s', outline: 'none' }}
+            onMouseEnter={e => { e.currentTarget.style.color = C.ink; e.currentTarget.style.background = C.creamCard; }}
+            onMouseLeave={e => { e.currentTarget.style.color = C.inkMid; e.currentTarget.style.background = 'none'; }}
+            title={dark ? 'Switch to light mode' : 'Switch to dark mode'}
+          >
+            {dark ? (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+              </svg>
+            ) : (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="4.5"/>
+                <line x1="12" y1="2" x2="12" y2="4.5"/>
+                <line x1="12" y1="19.5" x2="12" y2="22"/>
+                <line x1="4.22" y1="4.22" x2="5.93" y2="5.93"/>
+                <line x1="18.07" y1="18.07" x2="19.78" y2="19.78"/>
+                <line x1="2" y1="12" x2="4.5" y2="12"/>
+                <line x1="19.5" y1="12" x2="22" y2="12"/>
+                <line x1="4.22" y1="19.78" x2="5.93" y2="18.07"/>
+                <line x1="18.07" y1="5.93" x2="19.78" y2="4.22"/>
+              </svg>
+            )}
+          </button>
+          {isMobile ? (
+            <button onClick={() => setMenuOpen(o => !o)} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 8, display: 'flex', alignItems: 'center', color: C.inkMid }}>
+              {menuOpen ? (
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+              ) : (
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+              )}
+            </button>
+          ) : (
+            <a href="index.html#contact" style={{
+              background: ACC, color: '#fff', border: 'none', borderRadius: 100,
+              padding: '9px 20px', fontSize: 13, fontWeight: 600, cursor: 'pointer',
+              fontFamily: 'DM Sans', textDecoration: 'none', transition: 'opacity 0.2s',
+            }}
+              onMouseEnter={e => e.currentTarget.style.opacity = '0.85'}
+              onMouseLeave={e => e.currentTarget.style.opacity = '1'}
+            >Get in Touch</a>
+          )}
         </div>
+      </div>
+
+      {isMobile && menuOpen && (
+        <div style={{ padding: '8px 20px 20px', borderTop: `1px solid ${C.border}`, display: 'flex', flexDirection: 'column', gap: 4 }}>
+          {navLinks.map(([l,h]) => (
+            <a key={l} href={h} onClick={() => setMenuOpen(false)} style={{ fontFamily: 'DM Sans', fontSize: 15, fontWeight: 500, color: C.inkMid, textDecoration: 'none', padding: '10px 0', borderBottom: `1px solid ${C.border}`, transition: 'color 0.2s' }}
+              onMouseEnter={e => e.target.style.color = ACC}
+              onMouseLeave={e => e.target.style.color = C.inkMid}
+            >{l}</a>
+          ))}
+          <a href="index.html#contact" onClick={() => setMenuOpen(false)} style={{ background: ACC, color: '#fff', borderRadius: 100, padding: '12px 24px', fontSize: 14, fontWeight: 600, textDecoration: 'none', textAlign: 'center', marginTop: 8 }}>Get in Touch</a>
+        </div>
+      )}
+    </nav>
+  );
+}
+
+function Footer() {
+  const dark = React.useContext(ThemeCtx);
+  const w = useWindowWidth();
+  const isMobile = w < 640;
+  return (
+    <footer style={{ background: dark ? '#0D0B09' : '#1C1810', padding: `${isMobile ? 48 : 56}px ${hPad(w)} ${isMobile ? 24 : 32}px` }}>
+      <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : '2fr 1fr 1fr 1fr', gap: isMobile ? 32 : 40, paddingBottom: isMobile ? 32 : 48, borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+        <div style={{ gridColumn: isMobile ? '1 / -1' : 'auto' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16 }}>
+            <div style={{ width: 28, height: 28, borderRadius: 6, background: ACC, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'Playfair Display', fontWeight: 900, fontSize: 13, color: '#fff' }}>R</div>
+            <span style={{ fontFamily: 'DM Sans', fontWeight: 600, fontSize: 14, color: '#fff' }}>Rohan Vartak</span>
+          </div>
+          <p style={{ fontSize: 13, color: 'rgba(255,255,255,0.45)', lineHeight: 1.65, maxWidth: 240 }}>A data scientist on every team — building ML models that move the needle.</p>
+        </div>
+        {[
+          { label: 'Work', links: [['Projects','index.html#projects'],['Skills','index.html#skills'],['Resume','resume.html']] },
+          { label: 'Social', links: [['LinkedIn','https://www.linkedin.com/in/rohanvartak1996/'],['GitHub','https://github.com/rohanvartak96']] },
+          { label: 'Contact', links: [['Get in Touch','index.html#contact']] },
+        ].map(col => (
+          <div key={col.label}>
+            <p style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.3)', marginBottom: 16 }}>{col.label}</p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {col.links.map(([label, href]) => (
+                <a key={label} href={href} style={{ fontSize: 13, color: 'rgba(255,255,255,0.6)', textDecoration: 'none', transition: 'color 0.2s' }}
+                  onMouseEnter={e => e.target.style.color = ACC}
+                  onMouseLeave={e => e.target.style.color = 'rgba(255,255,255,0.6)'}
+                >{label}</a>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div style={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', justifyContent: 'space-between', alignItems: isMobile ? 'flex-start' : 'center', paddingTop: 24, gap: isMobile ? 8 : 0 }}>
+        <span style={{ fontSize: 12, color: 'rgba(255,255,255,0.3)' }}>Designed by Rohan Vartak © 2025</span>
+        <a href="mailto:rohanvartak1996@gmail.com" style={{ fontSize: 12, color: 'rgba(255,255,255,0.3)', textDecoration: 'none', transition: 'color 0.2s' }}
+          onMouseEnter={e => e.target.style.color = ACC}
+          onMouseLeave={e => e.target.style.color = 'rgba(255,255,255,0.3)'}
+        >rohanvartak1996@gmail.com</a>
+      </div>
     </footer>
-</body>
+  );
+}
 
+function ResumePage() {
+  const [dark, setDark] = useState(() => { try { return localStorage.getItem('theme') === 'dark'; } catch(e) { return false; } });
+  const T = dark ? CD : C;
+  const w = useWindowWidth();
+  const isMobile = w < 768;
+
+  useEffect(() => {
+    try { localStorage.setItem('theme', dark ? 'dark' : 'light'); } catch(e) {}
+    document.documentElement.classList.toggle('dark', dark);
+  }, [dark]);
+
+  return (
+    <ThemeCtx.Provider value={dark}>
+    <div style={{ background: T.cream, minHeight: '100vh', display: 'flex', flexDirection: 'column', transition: 'background 0.25s ease' }}>
+      <Nav dark={dark} setDark={setDark} />
+
+      <main style={{ flex: 1, paddingTop: 100, paddingBottom: 80, maxWidth: 900, margin: '0 auto', width: '100%', paddingLeft: isMobile ? 20 : 24, paddingRight: isMobile ? 20 : 24 }}>
+        <div style={{ marginBottom: 40 }}>
+          <p style={{ fontFamily: 'DM Sans', fontSize: 13, fontWeight: 500, letterSpacing: '0.18em', textTransform: 'uppercase', color: T.inkLight, marginBottom: 14 }}>Career History</p>
+          <h1 style={{ fontFamily: 'Playfair Display, serif', fontWeight: 900, fontSize: 'clamp(34px, 4vw, 56px)', letterSpacing: '-0.025em', color: T.ink, lineHeight: 1.0, marginBottom: 24 }}>
+            Rohan's <span style={{ fontStyle: 'italic', color: ACC }}>résumé.</span>
+          </h1>
+          <div style={{ display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap', marginBottom: 10 }}>
+            <a href="https://rohanvartak96.github.io/Rohan%20Vartak%20Resume.pdf" download
+              style={{ background: ACC, color: '#fff', border: 'none', borderRadius: 100, padding: '11px 24px', fontSize: 16, fontWeight: 600, cursor: 'pointer', fontFamily: 'DM Sans', textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 8, transition: 'opacity 0.2s' }}
+              onMouseEnter={e => e.currentTarget.style.opacity = '0.85'}
+              onMouseLeave={e => e.currentTarget.style.opacity = '1'}
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+              Download PDF
+            </a>
+            <a href="index.html"
+              style={{ background: 'transparent', color: T.ink, border: `1.5px solid ${T.borderMid}`, borderRadius: 100, padding: '10px 24px', fontSize: 16, fontWeight: 500, fontFamily: 'DM Sans', textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 6, transition: 'all 0.2s' }}
+              onMouseEnter={e => { e.currentTarget.style.borderColor = ACC; e.currentTarget.style.color = ACC; }}
+              onMouseLeave={e => { e.currentTarget.style.borderColor = T.borderMid; e.currentTarget.style.color = T.ink; }}
+            >← Back to Portfolio</a>
+          </div>
+          <p style={{ fontSize: 14, color: T.inkLight }}>Download the PDF for clickable links.</p>
+        </div>
+
+        <div style={{ background: T.white, border: `1px solid ${T.border}`, borderRadius: 16, overflow: 'hidden', boxShadow: '0 8px 48px rgba(28,24,16,0.10)' }}>
+          <div style={{ background: T.creamCard, borderBottom: `1px solid ${T.border}`, padding: '12px 20px', display: 'flex', alignItems: 'center', gap: 8 }}>
+            <div style={{ width: 10, height: 10, borderRadius: '50%', background: '#EC6B5E' }}></div>
+            <div style={{ width: 10, height: 10, borderRadius: '50%', background: '#F5BE4F' }}></div>
+            <div style={{ width: 10, height: 10, borderRadius: '50%', background: '#67C65E' }}></div>
+            <span style={{ marginLeft: 8, fontSize: 13, color: T.inkLight, fontWeight: 500 }}>
+              <span style={{ color: T.ink, fontWeight: 600 }}>Rohan Vartak Resume.pdf</span> · 1 page
+            </span>
+          </div>
+          <iframe
+            src="https://rohanvartak96.github.io/Rohan%20Vartak%20Resume.pdf"
+            title="Rohan Vartak Resume"
+            style={{ width: '100%', height: isMobile ? '70vh' : '85vh', border: 'none', display: 'block' }}
+          ></iframe>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+    </ThemeCtx.Provider>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<ResumePage />);
+</script>
+</body>
 </html>

--- a/style.css
+++ b/style.css
@@ -73,13 +73,13 @@ nav {
 
 nav .left a {
     color: var(--text-color);
-    font-size: 24px;
+    font-size: 26px;
     font-weight: 600;
 }
 
 nav .right a {
     color: #666;
-    font-size: 15px;
+    font-size: 17px;
     margin-left: 8px;
     display: inline-flex;
     align-items: center;
@@ -181,7 +181,7 @@ nav .right a.nav-link--cta.active {
         padding: 12px 16px;
         border-radius: 10px;
         margin-left: 0;
-        font-size: 16px;
+        font-size: 18px;
     }
 
     nav .right a.nav-link--cta {
@@ -249,14 +249,14 @@ nav .right a.nav-link--cta.active {
 }
 
 .hero-section .hero-heading h2 {
-    font-size: 48px;
+    font-size: 50px;
     font-weight: 600;
     line-height: 1.2;
     margin-bottom: 10px;
 }
 
 .hero-section .job-title {
-    font-size: 48px;
+    font-size: 50px;
     color: var(--primary-color);
     margin: 0;
     font-weight: 700;
@@ -279,7 +279,7 @@ nav .right a.nav-link--cta.active {
 }
 
 .hero-section .headshot .headshot-text p {
-    font-size: 20px;
+    font-size: 22px;
     margin-bottom: 10px;
     color: var(--text-color);
 }
@@ -287,7 +287,7 @@ nav .right a.nav-link--cta.active {
 .hero-section .headshot .headshot-text p:first-of-type {
     color: var(--primary-color);
     font-weight: 600;
-    font-size: 22px;
+    font-size: 24px;
     margin-bottom: 15px;
 }
 
@@ -339,7 +339,7 @@ nav .right a.nav-link--cta.active {
 }
 
 .hero-section .text p:not(.role-target) {
-    font-size: 20px;
+    font-size: 22px;
     color: var(--muted-text);
     line-height: 1.7;
     margin-bottom: 10px;
@@ -349,7 +349,7 @@ nav .right a.nav-link--cta.active {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    font-size: 16px;
+    font-size: 18px;
     color: var(--text-color);
     background-color: rgba(34, 197, 94, 0.08);
     border: 1px solid rgba(34, 197, 94, 0.25);
@@ -360,7 +360,7 @@ nav .right a.nav-link--cta.active {
 }
 
 .pulse-green {
-    font-size: 10px;
+    font-size: 12px;
     color: #22c55e;
     animation: pulse-green 1.8s ease-in-out infinite;
 }
@@ -381,7 +381,7 @@ nav .right a.nav-link--cta.active {
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    font-size: 13px;
+    font-size: 15px;
     font-weight: 600;
     padding: 9px 20px;
     border-radius: 50px;
@@ -440,7 +440,7 @@ nav .right a.nav-link--cta.active {
 
 .skills-section h2 {
     text-align: center;
-    font-size: 36px;
+    font-size: 38px;
     margin-bottom: 50px;
 }
 
@@ -457,7 +457,7 @@ nav .right a.nav-link--cta.active {
 }
 
 .skill-group-label {
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.1em;
@@ -521,7 +521,7 @@ nav .right a.nav-link--cta.active {
 }
 
 .metric-value {
-    font-size: 22px;
+    font-size: 24px;
     font-weight: 700;
     color: var(--text-color);
     letter-spacing: -0.3px;
@@ -529,7 +529,7 @@ nav .right a.nav-link--cta.active {
 }
 
 .metric-label {
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 500;
     color: #888;
     text-transform: uppercase;
@@ -561,11 +561,11 @@ nav .right a.nav-link--cta.active {
     }
     .metric-divider { display: none; }
     .metric { flex: 1 1 40%; }
-    .metric-value { font-size: 18px; }
+    .metric-value { font-size: 20px; }
 
-    .hero-section .headshot .headshot-text p { font-size: 16px; }
-    .hero-section .headshot .headshot-text p:first-of-type { font-size: 18px; }
-    .hero-section .text p:not(.role-target) { font-size: 16px; }
+    .hero-section .headshot .headshot-text p { font-size: 18px; }
+    .hero-section .headshot .headshot-text p:first-of-type { font-size: 20px; }
+    .hero-section .text p:not(.role-target) { font-size: 18px; }
     .hero-cta { justify-content: center; }
 
     .project-card:not(.project-card--featured) { padding: 20px; }
@@ -599,7 +599,7 @@ nav .right a.nav-link--cta.active {
 
 .projects-section h2 {
     text-align: center;
-    font-size: 36px;
+    font-size: 38px;
     margin-bottom: 60px;
 }
 
@@ -608,7 +608,7 @@ nav .right a.nav-link--cta.active {
 }
 
 .projects-subsection-title {
-    font-size: 20px;
+    font-size: 22px;
     font-weight: 700;
     color: var(--text-color);
     letter-spacing: 0.04em;
@@ -732,7 +732,7 @@ nav .right a.nav-link--cta.active {
     gap: 8px;
     background: #fff;
     color: var(--primary-color);
-    font-size: 13px;
+    font-size: 15px;
     font-weight: 700;
     padding: 9px 20px;
     border-radius: 50px;
@@ -770,14 +770,14 @@ nav .right a.nav-link--cta.active {
 }
 
 .project-card .project-title {
-    font-size: 20px;
+    font-size: 22px;
     font-weight: 600;
     color: var(--text-color);
     margin-bottom: 12px;
 }
 
 .project-card .project-outcome {
-    font-size: 15px;
+    font-size: 17px;
     color: var(--muted-text);
     line-height: 1.6;
     margin-bottom: 20px;
@@ -791,7 +791,7 @@ nav .right a.nav-link--cta.active {
 }
 
 .project-tags .tag {
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 600;
     color: var(--primary-color);
     background-color: rgba(114, 57, 247, 0.08);
@@ -803,7 +803,7 @@ nav .right a.nav-link--cta.active {
 .project-card .project-link {
     display: inline-flex;
     align-items: center;
-    font-size: 14px;
+    font-size: 16px;
     font-weight: 600;
     color: var(--primary-color);
     text-decoration: none;
@@ -836,7 +836,7 @@ nav .right a.nav-link--cta.active {
 
 .testimonial-highlights h2 {
     text-align: center;
-    font-size: 36px;
+    font-size: 38px;
     margin-bottom: 60px;
 }
 
@@ -878,7 +878,7 @@ nav .right a.nav-link--cta.active {
     border-radius: 50%;
     background: rgba(114, 57, 247, 0.1);
     color: var(--primary-color);
-    font-size: 14px;
+    font-size: 16px;
     font-weight: 700;
     display: flex;
     align-items: center;
@@ -888,7 +888,7 @@ nav .right a.nav-link--cta.active {
 }
 
 .testimonial-quote {
-    font-size: 15px;
+    font-size: 17px;
     font-style: normal;
     line-height: 1.75;
     color: var(--text-color);
@@ -906,18 +906,18 @@ nav .right a.nav-link--cta.active {
 }
 
 .highlight-card .testimonial-author .name {
-    font-size: 14px;
+    font-size: 16px;
     font-weight: 700;
     color: var(--text-color);
 }
 
 .highlight-card .testimonial-author .separator {
-    font-size: 14px;
+    font-size: 16px;
     color: #aaa;
 }
 
 .highlight-card .testimonial-author .position {
-    font-size: 11px;
+    font-size: 13px;
     font-weight: 600;
     color: #888;
     text-transform: uppercase;
@@ -943,7 +943,7 @@ nav .right a.nav-link--cta.active {
 }
 
 .section-eyebrow {
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.1em;
@@ -952,7 +952,7 @@ nav .right a.nav-link--cta.active {
 }
 
 .contact-heading {
-    font-size: 36px;
+    font-size: 38px;
     font-weight: 700;
     line-height: 1.2;
     letter-spacing: -0.4px;
@@ -961,7 +961,7 @@ nav .right a.nav-link--cta.active {
 }
 
 .contact-subheading {
-    font-size: 34px;
+    font-size: 36px;
     font-weight: 700;
     color: var(--primary-color);
     margin-bottom: 52px;
@@ -969,7 +969,7 @@ nav .right a.nav-link--cta.active {
 }
 
 .connect-label {
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.1em;
@@ -984,7 +984,7 @@ nav .right a.nav-link--cta.active {
 
 .social-links a {
     color: var(--text-color);
-    font-size: 36px;
+    font-size: 38px;
     opacity: 0.75;
     transition: color 0.2s ease, transform 0.2s ease, opacity 0.2s ease;
 }
@@ -1012,7 +1012,7 @@ nav .right a.nav-link--cta.active {
     padding: 14px 18px;
     outline: none;
     width: 100%;
-    font-size: 15px;
+    font-size: 17px;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -1033,7 +1033,7 @@ nav .right a.nav-link--cta.active {
 }
 
 .contact-right button {
-    font-size: 15px;
+    font-size: 17px;
     font-family: var(--font-family);
     color: #fff;
     background: var(--primary-color);
@@ -1065,8 +1065,8 @@ nav .right a.nav-link--cta.active {
         gap: 40px;
     }
 
-    .contact-heading { font-size: 26px; }
-    .contact-subheading { font-size: 24px; }
+    .contact-heading { font-size: 28px; }
+    .contact-subheading { font-size: 26px; }
 }
 
 /* Footer */
@@ -1079,7 +1079,7 @@ nav .right a.nav-link--cta.active {
 }
 
 .footer-section p {
-    font-size: 14px;
+    font-size: 16px;
     color: var(--muted-text);
     margin-bottom: 20px;
     font-weight: 500;
@@ -1093,7 +1093,7 @@ nav .right a.nav-link--cta.active {
 
 .footer-links a {
     color: var(--text-color);
-    font-size: 22px;
+    font-size: 24px;
     transition: all 0.3s ease;
     opacity: 0.8;
 }
@@ -1123,14 +1123,14 @@ nav .right a.nav-link--cta.active {
 
     .hero-section .hero-heading h2,
     .hero-section .job-title {
-        font-size: 36px;
+        font-size: 38px;
     }
 }
 
 @media (max-width: 600px) {
     .hero-section .hero-heading h2,
     .hero-section .job-title {
-        font-size: 30px;
+        font-size: 32px;
     }
 
     .hero-section {
@@ -1218,7 +1218,7 @@ nav .right a.nav-link--cta.active {
     border-radius: 8px;
     cursor: pointer;
     font-family: var(--font-family);
-    font-size: 13px;
+    font-size: 15px;
     font-weight: 500;
     transition: all 0.2s ease;
     white-space: nowrap;
@@ -1240,7 +1240,7 @@ nav .right a.nav-link--cta.active {
 }
 
 .pdf-name {
-    font-size: 15px;
+    font-size: 17px;
     font-weight: 600;
     color: #fff;
     font-family: var(--font-family);
@@ -1248,12 +1248,12 @@ nav .right a.nav-link--cta.active {
 
 .pdf-dot {
     color: rgba(255, 255, 255, 0.3);
-    font-size: 18px;
+    font-size: 20px;
     line-height: 1;
 }
 
 .pdf-label {
-    font-size: 14px;
+    font-size: 16px;
     color: rgba(255, 255, 255, 0.45);
     font-family: var(--font-family);
 }
@@ -1275,7 +1275,7 @@ nav .right a.nav-link--cta.active {
     padding: 5px 12px;
     color: rgba(255, 255, 255, 0.7);
     font-family: var(--font-family);
-    font-size: 13px;
+    font-size: 15px;
     font-weight: 600;
 }
 
@@ -1285,7 +1285,7 @@ nav .right a.nav-link--cta.active {
     color: rgba(255, 255, 255, 0.6);
     cursor: pointer;
     padding: 2px 4px;
-    font-size: 12px;
+    font-size: 14px;
     transition: color 0.2s ease;
     line-height: 1;
 }
@@ -1310,7 +1310,7 @@ nav .right a.nav-link--cta.active {
     border-radius: 8px;
     cursor: pointer;
     font-family: var(--font-family);
-    font-size: 13px;
+    font-size: 15px;
     font-weight: 600;
     text-decoration: none;
     transition: all 0.2s ease;
@@ -1394,7 +1394,7 @@ nav .right a.nav-link--cta.active {
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 16px;
+    font-size: 18px;
     box-shadow: 0 4px 20px rgba(114, 57, 247, 0.4);
     opacity: 0;
     transform: translateY(12px);


### PR DESCRIPTION
- Rewrote index.html as a React SPA (Babel standalone, no build step)
  - New design system: Playfair Display + DM Sans, warm cream/ink palette
  - Dark mode via ThemeCtx / useC() hook, anti-flash localStorage script
  - Nav: fixed, frosted-glass on scroll, dark mode toggle (sun/moon SVGs), mobile hamburger
  - Hero: animated flip-word role titles, CTA buttons, dot-grid background
  - Projects, Skills, Testimonials, Contact, Footer sections with scroll-reveal animations
  - Animated stat counters (useCounter) and responsive layout (useWindowWidth / hPad)
- resume.html: ported to same React + dark mode architecture
- projects/instagram-latency.html and user-language-model.html: dark mode support added
- style.css / projects.css: cleaned up legacy CSS (orphaned files, no longer linked)
- CLAUDE.md: added project-level coding instructions for dark mode patterns, component conventions, and design system rules