### PR TITLE
Add "Open to ML / DS Roles" availability badge to hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@ html { scroll-behavior: smooth; }
 body { background: #F4EFE6; color: #1C1810; font-family: 'DM Sans', sans-serif; -webkit-font-smoothing: antialiased; transition: background 0.25s ease, color 0.25s ease; }
 html.dark body { background: #1C1A17; color: #F0EBE1; }
 ::selection { background: #D95F2B; color: #fff; }
+@keyframes availPulse { 0% { box-shadow: 0 0 0 0 rgba(31,164,99,0.5); } 70% { box-shadow: 0 0 0 6px rgba(31,164,99,0); } 100% { box-shadow: 0 0 0 0 rgba(31,164,99,0); } }
 </style>
 <script>(function(){try{if(localStorage.getItem('theme')==='dark')document.documentElement.classList.add('dark');}catch(e){}})()</script>
 <script type="application/ld+json">
@@ -103,6 +104,7 @@ html.dark body { background: #1C1A17; color: #F0EBE1; }
 const { useState, useEffect, useRef } = React;
 
 const ACC = '#D95F2B';
+const GREEN = '#1FA463';
 const C = {
   cream:     '#F4EFE6',
   creamDark: '#EDE5D8',
@@ -311,7 +313,12 @@ function Hero() {
       <div style={{ position: 'absolute', inset: 0, backgroundImage: `radial-gradient(circle, ${C.border} 1px, transparent 1px)`, backgroundSize: '28px 28px', pointerEvents: 'none', opacity: 0.6 }}></div>
 
       <div style={{ flex: '1 1 0', maxWidth: isMobile ? '100%' : 620, paddingTop: isMobile ? 0 : 80, paddingBottom: isMobile ? 0 : 80, position: 'relative', width: '100%' }}>
-        <div style={{ height: isMobile ? 0 : 37, marginBottom: isMobile ? 16 : 28 }}></div>
+        <div style={{ minHeight: isMobile ? 0 : 37, marginBottom: isMobile ? 16 : 28, display: 'flex', alignItems: 'center' }}>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 9, background: `${GREEN}15`, border: `1px solid ${GREEN}38`, borderRadius: 100, padding: '6px 14px 6px 12px' }}>
+            <span style={{ width: 8, height: 8, borderRadius: '50%', background: GREEN, flexShrink: 0, animation: 'availPulse 2s infinite' }}></span>
+            <span style={{ fontFamily: 'DM Sans', fontSize: 12.5, fontWeight: 600, letterSpacing: '0.02em', color: GREEN }}>Open to ML / DS Roles</span>
+          </span>
+        </div>
 
         <p style={{ fontFamily: 'DM Sans', fontSize: 11, fontWeight: 500, letterSpacing: '0.18em', textTransform: 'uppercase', color: C.inkLight, marginBottom: 18 }}>Data Scientist &amp; ML Engineer at Meta</p>
 


### PR DESCRIPTION
## Summary

Adds a pulsing green **"Open to ML / DS Roles"** availability status badge to the home-page hero, signaling active job-search availability to visitors.

## Changes

- **`index.html`**
  - New availability pill above the hero eyebrow: green status dot + "Open to ML / DS Roles" label
  - Adds an `availPulse` CSS keyframe so the status dot gently pulses (2s loop)
  - Adds a `GREEN` accent constant (`#1FA463`) alongside the existing `ACC`
  - Replaces the hero's top spacer `<div>` (kept vertical rhythm intact)

## Notes

- Fully **light/dark-mode aware** — the pill uses translucent green tints (matching the existing tag/pill pattern) that read well on both backgrounds.
- Verified the JSX compiles and the full home-page component tree server-renders with no runtime errors; badge visuals checked in both themes via an isolated render.
- Scoped to only the badge — the Region Prediction Model work is already in `main` via #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDERrSw3cKPmZgns35ps1n

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDERrSw3cKPmZgns35ps1n)_